### PR TITLE
Fix: Prevent OS env config from overriding testing configs

### DIFF
--- a/src/apps/backend/modules/config/config_manager.py
+++ b/src/apps/backend/modules/config/config_manager.py
@@ -22,8 +22,9 @@ class ConfigManager:
     def mount_config() -> None:
         ConfigManager.config = {**ConfigManager.config, **asdict(DefaultSettings())}
         ConfigManager.config = {**ConfigManager.config, **ConfigManager._load_app_env_settings()}
-        not_nullable_os_envs = {k: v for k, v in asdict(OSSettings()).items() if v is not None}
-        ConfigManager.config = {**ConfigManager.config, **not_nullable_os_envs}
+        if os.environ.get("APP_ENV") not in {AppEnv.TESTING, AppEnv.DOCKER_INSTANCE_TEST}:
+            not_nullable_os_envs = {k: v for k, v in asdict(OSSettings()).items() if v is not None}
+            ConfigManager.config = {**ConfigManager.config, **not_nullable_os_envs}
         print("Config is ==", ConfigManager.config)
 
     @staticmethod

--- a/src/apps/backend/settings/testing.py
+++ b/src/apps/backend/settings/testing.py
@@ -1,9 +1,16 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
 class TestingSettings:
     MONGODB_URI: str = "mongodb://localhost:27017/frm-boilerplate-test"
+    MAILER: dict[str, str] = field(
+        default_factory=lambda: {
+            "default_email": "DEFAULT_EMAIL",
+            "default_email_name": "DEFAULT_EMAIL_NAME",
+            "forgot_password_mail_template_id": "FORGOT_PASSWORD_MAIL_TEMPLATE_ID",
+        }
+    )
 
 
 @dataclass(frozen=True)

--- a/src/apps/backend/settings/testing.py
+++ b/src/apps/backend/settings/testing.py
@@ -16,3 +16,10 @@ class TestingSettings:
 @dataclass(frozen=True)
 class DockerInstanceTestingSettings:
     MONGODB_URI: str = "mongodb://db:27017/frm-boilerplate-test"
+    MAILER: dict[str, str] = field(
+        default_factory=lambda: {
+            "default_email": "DEFAULT_EMAIL",
+            "default_email_name": "DEFAULT_EMAIL_NAME",
+            "forgot_password_mail_template_id": "FORGOT_PASSWORD_MAIL_TEMPLATE_ID",
+        }
+    )


### PR DESCRIPTION
## Description
_This PR fixes the issue of OS env configuration overriding the testing configs._

## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
NA
