### PR TITLE
fix: expired token error

### DIFF
--- a/src/apps/backend/modules/access_token/access_token_service.py
+++ b/src/apps/backend/modules/access_token/access_token_service.py
@@ -37,8 +37,7 @@ class AccessTokenService:
             verified_token = jwt.decode(token, jwt_signing_key, algorithms=["HS256"])
         except jwt.exceptions.DecodeError:
             raise AccessTokenInvalidError("Invalid access token")
-
-        if verified_token.get("exp") * 1000 < datetime.now().timestamp() * 1000:
+        except jwt.ExpiredSignatureError:
             raise AccessTokenExpiredError(message="Access token has expired. Please login again.")
 
         return AccessTokenPayload(account_id=verified_token.get("account_id"))

--- a/src/apps/backend/modules/access_token/rest_api/access_auth_middleware.py
+++ b/src/apps/backend/modules/access_token/rest_api/access_auth_middleware.py
@@ -5,7 +5,6 @@ from flask import request
 
 from modules.access_token.access_token_service import AccessTokenService
 from modules.access_token.errors import (
-    AccessTokenInvalidError,
     AuthorizationHeaderNotFoundError,
     InvalidAuthorizationHeaderError,
     UnauthorizedAccessError,
@@ -23,10 +22,7 @@ def access_auth_middleware(next_func: Callable) -> Callable:
         if auth_scheme != "Bearer" or not auth_token:
             raise InvalidAuthorizationHeaderError("Invalid authorization header.")
 
-        try:
-            auth_payload = AccessTokenService.verify_access_token(token=auth_token)
-        except AccessTokenInvalidError:
-            raise InvalidAuthorizationHeaderError("Invalid authorization header.")
+        auth_payload = AccessTokenService.verify_access_token(token=auth_token)
 
         if "account_id" in kwargs and auth_payload.account_id != kwargs["account_id"]:
             raise UnauthorizedAccessError("Unauthorized access.")

--- a/src/apps/backend/tests/modules/access_token/test_access_auth_middleware.py
+++ b/src/apps/backend/tests/modules/access_token/test_access_auth_middleware.py
@@ -13,6 +13,8 @@ from modules.access_token.errors import (
 from modules.access_token.rest_api.access_auth_middleware import access_auth_middleware
 from server import app
 
+TEST_TOKEN = "your_test_token"
+
 
 class TestAccessAuthMiddleware(unittest.TestCase):
     @patch("modules.access_token.access_token_service.AccessTokenService.verify_access_token")
@@ -30,7 +32,7 @@ class TestAccessAuthMiddleware(unittest.TestCase):
         mock_next_func = MagicMock()
 
         with app.test_request_context():
-            request.headers = {"Authorization": "JWT your_test_token"}
+            request.headers = {"Authorization": f"JWT {TEST_TOKEN}"}
             with self.assertRaises(InvalidAuthorizationHeaderError):
                 access_auth_middleware(mock_next_func)()
 
@@ -42,7 +44,7 @@ class TestAccessAuthMiddleware(unittest.TestCase):
         mock_verify_access_token.side_effect = AccessTokenInvalidError("Invalid access token.")
 
         with app.test_request_context():
-            request.headers = {"Authorization": "Bearer your_test_token"}
+            request.headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
             with self.assertRaises(AccessTokenInvalidError):
                 access_auth_middleware(mock_next_func)()
 
@@ -56,7 +58,7 @@ class TestAccessAuthMiddleware(unittest.TestCase):
         def test_view_func(account_id):
             return account_id
 
-        with app.test_request_context(headers={"Authorization": "Bearer your_test_token"}):
+        with app.test_request_context(headers={"Authorization": f"Bearer {TEST_TOKEN}"}):
             with self.assertRaises(UnauthorizedAccessError):
                 test_view_func(account_id="67890")
 
@@ -65,7 +67,7 @@ class TestAccessAuthMiddleware(unittest.TestCase):
         mock_next_func = MagicMock()
         mock_verify_access_token.side_effect = AccessTokenExpiredError("Access token has expired. Please login again.")
 
-        with app.test_request_context(headers={"Authorization": "Bearer your_test_token"}):
+        with app.test_request_context(headers={"Authorization": f"Bearer {TEST_TOKEN}"}):
             with self.assertRaises(AccessTokenExpiredError):
                 access_auth_middleware(mock_next_func)()
 

--- a/src/apps/backend/tests/modules/account/test_account_api.py
+++ b/src/apps/backend/tests/modules/account/test_account_api.py
@@ -114,3 +114,4 @@ class TestAccountApi(BaseTestAccount):
 
             assert response.status_code == 401
             assert "Access token has expired. Please login again." in response.json.get("message", "")
+            assert response.json.get("code") == AccessTokenErrorCode.ACCESS_TOKEN_EXPIRED

--- a/src/apps/backend/tests/modules/account/test_account_api.py
+++ b/src/apps/backend/tests/modules/account/test_account_api.py
@@ -1,7 +1,12 @@
 import json
+from datetime import datetime, timedelta
 
+import jwt
+
+from modules.access_token.types import AccessTokenErrorCode
 from modules.account.account_service import AccountService
 from modules.account.types import AccountErrorCode, CreateAccountParams
+from modules.config.config_service import ConfigService
 from server import app
 from tests.modules.account.base_test_account import BaseTestAccount
 
@@ -42,3 +47,70 @@ class TestAccountApi(BaseTestAccount):
         assert response.status_code == 409
         assert response.json
         assert response.json.get("code") == AccountErrorCode.USERNAME_ALREADY_EXISTS
+
+    def test_get_account_by_username_and_password(self) -> None:
+        account = AccountService.create_account(
+            params=CreateAccountParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        with app.test_client() as client:
+            access_token = client.post(
+                "http://127.0.0.1:8080/api/access-tokens",
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"username": account.username, "password": "password"}),
+            )
+            response = client.get(
+                f"http://127.0.0.1:8080/api/accounts/{account.id}",
+                headers={"Authorization": f"Bearer {access_token.json.get('token')}"},
+            )
+            assert response.status_code == 200
+            assert response.json
+            assert response.json.get("id") == account.id
+            assert response.json.get("username") == account.username
+            assert response.json.get("first_name") == account.first_name
+            assert response.json.get("last_name") == account.last_name
+
+    def test_get_account_by_username_and_password_with_invalid_password(self) -> None:
+        account = AccountService.create_account(
+            params=CreateAccountParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        with app.test_client() as client:
+            access_token = client.post(
+                "http://127.0.0.1:8080/api/access-tokens",
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"username": account.username, "password": "password"}),
+            )
+            response = client.get(
+                f"http://127.0.0.1:8080/api/accounts/{account.id}", headers={"Authorization": f"Bearer invalid_token"}
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.ACCESS_TOKEN_INVALID
+
+    def test_get_account_with_expired_access_token(self) -> None:
+        account = AccountService.create_account(
+            params=CreateAccountParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        # Create an expired token by setting the expiry to a date in the past using same method as in the
+        # access token service
+        jwt_signing_key = ConfigService.get_token_signing_key()
+        jwt_expiry = timedelta(days=ConfigService.get_token_expiry_days() - 1)
+        payload = {"account_id": account.id, "exp": (datetime.now() - jwt_expiry).timestamp()}
+        expired_token = jwt.encode(payload, jwt_signing_key, algorithm="HS256")
+
+        with app.test_client() as client:
+            response = client.get(
+                f"http://127.0.0.1:8080/api/accounts/{account.id}", headers={"Authorization": f"Bearer {expired_token}"}
+            )
+
+            assert response.status_code == 401
+            assert "Access token has expired. Please login again." in response.json.get("message", "")

--- a/src/apps/backend/tests/modules/account/test_account_api.py
+++ b/src/apps/backend/tests/modules/account/test_account_api.py
@@ -10,6 +10,8 @@ from modules.config.config_service import ConfigService
 from server import app
 from tests.modules.account.base_test_account import BaseTestAccount
 
+HEADERS = {"Content-Type": "application/json"}
+
 
 class TestAccountApi(BaseTestAccount):
     def test_create_account(self) -> None:
@@ -18,9 +20,7 @@ class TestAccountApi(BaseTestAccount):
         )
 
         with app.test_client() as client:
-            response = client.post(
-                "http://127.0.0.1:8080/api/accounts", headers={"Content-Type": "application/json"}, data=payload
-            )
+            response = client.post("http://127.0.0.1:8080/api/accounts", headers=HEADERS, data=payload)
             assert response.status_code == 201
             assert response.json, f"No response from API with status code:: {response.status}"
             assert response.json.get("username") == "username"
@@ -34,7 +34,7 @@ class TestAccountApi(BaseTestAccount):
         with app.test_client() as client:
             response = client.post(
                 "http://127.0.0.1:8080/api/accounts",
-                headers={"Content-Type": "application/json"},
+                headers=HEADERS,
                 data=json.dumps(
                     {
                         "first_name": "first_name",
@@ -58,7 +58,7 @@ class TestAccountApi(BaseTestAccount):
         with app.test_client() as client:
             access_token = client.post(
                 "http://127.0.0.1:8080/api/access-tokens",
-                headers={"Content-Type": "application/json"},
+                headers=HEADERS,
                 data=json.dumps({"username": account.username, "password": "password"}),
             )
             response = client.get(
@@ -80,9 +80,9 @@ class TestAccountApi(BaseTestAccount):
         )
 
         with app.test_client() as client:
-            access_token = client.post(
+            client.post(
                 "http://127.0.0.1:8080/api/access-tokens",
-                headers={"Content-Type": "application/json"},
+                headers=HEADERS,
                 data=json.dumps({"username": account.username, "password": "password"}),
             )
             response = client.get(


### PR DESCRIPTION
## Description
_This PR resolves the issue of the backend API returning http code 500 instead of 401._

## Database schema changes
NA

## Tests
### Automated test cases added
- Access Auth Middleware
  - Modified existing case for InvalidAccessToken, previously it was InvalidAuthHeader
  - Added case for ExpiredAccessToken
- Account Api GET /accounts/:account_id
  - should return account details when AccessToken in Header is `Valid`
  - should throw `ACCESS_TOKEN_ERR_05` when AccessToken provided is `invalid`
  - should throw `ACCESS_TOKEN_ERR_02` when AccessToken provided is `expired`

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
NA