### PR TITLE
fix: Local docker compose setup with hot reloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ run-engine:
 	cd src/apps/backend \
 	&& pipenv install --dev \
 	&& pipenv run python --version \
-	&& pipenv run gunicorn -c gunicorn_config.py server:app
+	&& pipenv run gunicorn -c gunicorn_config.py --reload server:app
 
 run-test:
 	cd src/apps/backend \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
         APP_ENV: 'docker-dev'
     environment:
       APP_ENV: 'docker-dev'
-    command: 'npm run serve'
+    command: /bin/sh -c "npm install && npm run serve"
     depends_on:
       - db
     ports:
@@ -20,7 +20,7 @@ services:
     volumes:
       - './:/app:delegated'
       - '/app/node_modules/'
-    working_dir: /root/app
+    working_dir: /app
 
   db:
     image: mongo:5.0


### PR DESCRIPTION
## Description
_This PR fixes the issue of docker compose not working on local machines for development._

## Changes
- Added `npm install` script before `npm serve` to install devDepencencies before starting server
- Added `--reload` in `make engine` to ensure hot reloading of backend server

## Video
_[Video](https://jalantechnology-my.sharepoint.com/personal/abhishek_verma_jalantechnologies_com/_layouts/15/stream.aspx?id=%2Fpersonal%2Fabhishek%5Fverma%5Fjalantechnologies%5Fcom%2FDocuments%2FScreen%20Recording%202024%2D09%2D09%20at%2012%2E04%2E13%2Emov&referrer=StreamWebApp%2EWeb&referrerScenario=AddressBarCopied%2Eview%2E9458cba9%2Deb45%2D49da%2D9de4%2D4961f66b3a05) demonstrating docker compose working and hot reload on frontend._

_[Video](https://jalantechnology-my.sharepoint.com/personal/abhishek_verma_jalantechnologies_com/_layouts/15/stream.aspx?id=%2Fpersonal%2Fabhishek%5Fverma%5Fjalantechnologies%5Fcom%2FDocuments%2FScreen%20Recording%202024%2D09%2D09%20at%2012%2E10%2E22%2Emov&referrer=StreamWebApp%2EWeb&referrerScenario=AddressBarCopied%2Eview%2Eadbcae79%2D1cca%2D4a63%2Db1eb%2Da6305d3a7e7c) demonstrating hot reloading on backend server._


## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- ran `docker compose -f docker-compose.dev.yml up` as mentioned in readme and made file changes to check hot reload is working
