### PR TITLE
Fix: Handle error and logout on failed account details retrieval

### DIFF
--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -1,17 +1,26 @@
 import React, { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { Outlet, useNavigate } from 'react-router-dom';
 
-import { useAccountContext } from '../contexts';
+import routes from '../constants/routes';
+import { useAccountContext, useAuthContext } from '../contexts';
 import { Dashboard, NotFound } from '../pages';
 import AppLayout from '../pages/app-layout/app-layout';
+import { AsyncError } from '../types';
 
 const App = () => {
   const { getAccountDetails } = useAccountContext();
+  const { logout } = useAuthContext();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    getAccountDetails();
-  }, [getAccountDetails]);
+    getAccountDetails()
+      .catch((err: AsyncError) => {
+        toast.error(err.message);
+        logout();
+        navigate(routes.LOGIN);
+      });
+  }, [getAccountDetails, logout, navigate]);
 
   return (
     <AppLayout>


### PR DESCRIPTION
## Description
_This PR resolves the issue of not handling `invalid` or `expired` access token in frontend.
This closes #43 issue_

## Video
_Video demonstrating the scenario, when the token signing key is changed._


https://github.com/user-attachments/assets/0849a00d-2fbe-4a52-b705-5dc473a8f2a7



## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- Logged in with a randon access token signing key, then changed the signing and restarted app. Now successfully logging out with a toast in both cases i.e., `invalid` or `expired` access token
