### PR TITLE
fix: clean_on_pr_closed workflow not getting triggered incase if the PR consists merge conflicts

### DIFF
--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -1,7 +1,7 @@
 name: clean_on_pr_closed
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
 jobs:

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -14,12 +14,11 @@ const App = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    getAccountDetails()
-      .catch((err: AsyncError) => {
-        toast.error(err.message);
-        logout();
-        navigate(routes.LOGIN);
-      });
+    getAccountDetails().catch((err: AsyncError) => {
+      toast.error(err.message);
+      logout();
+      navigate(routes.LOGIN);
+    });
   }, [getAccountDetails, logout, navigate]);
 
   return (


### PR DESCRIPTION
## Description
This PR introduces the fix for the issue #63, in which `clean_on_pr_closed` workflow is not getting triggered incase if the PR consists merge conflicts. Replaced `pull_request` event trigger with `pull_request_target` as a fix for this problem.

Plase note:
- The pull_request_target event will not trigger if the workflow is just placed in the .github/workflows directory of the PR's head branch, but it must exist in the base branch. We should make sure the workflow exists in the base branch at the time the PR is opened. So moving forward this will work as expected but won't work for the existing PR's until their base branch have been edited and added as `main`.

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- NA (refer [PR](https://github.com/jalantechnologies/boilerplate-mern/pull/167))

