### PR TITLE
chore: Refactor App Service

### DIFF
--- a/src/apps/backend/modules/access_token/errors.py
+++ b/src/apps/backend/modules/access_token/errors.py
@@ -4,26 +4,26 @@ from modules.error.custom_errors import AppError
 
 class AccessTokenInvalidError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccessTokenErrorCode.ACCESS_TOKEN_INVALID, https_status_code=401, message=message)
+        super().__init__(code=AccessTokenErrorCode.ACCESS_TOKEN_INVALID, http_status_code=401, message=message)
 
 
 class AccessTokenExpiredError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccessTokenErrorCode.ACCESS_TOKEN_EXPIRED, https_status_code=401, message=message)
+        super().__init__(code=AccessTokenErrorCode.ACCESS_TOKEN_EXPIRED, http_status_code=401, message=message)
 
 
 class UnauthorizedAccessError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccessTokenErrorCode.UNAUTHORIZED_ACCESS, https_status_code=401, message=message)
+        super().__init__(code=AccessTokenErrorCode.UNAUTHORIZED_ACCESS, http_status_code=401, message=message)
 
 
 class AuthorizationHeaderNotFoundError(AppError):
     def __init__(self, message: str) -> None:
         super().__init__(
-            code=AccessTokenErrorCode.AUTHORIZATION_HEADER_NOT_FOUND, https_status_code=401, message=message
+            code=AccessTokenErrorCode.AUTHORIZATION_HEADER_NOT_FOUND, http_status_code=401, message=message
         )
 
 
 class InvalidAuthorizationHeaderError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccessTokenErrorCode.INVALID_AUTHORIZATION_HEADER, https_status_code=401, message=message)
+        super().__init__(code=AccessTokenErrorCode.INVALID_AUTHORIZATION_HEADER, http_status_code=401, message=message)

--- a/src/apps/backend/modules/account/errors.py
+++ b/src/apps/backend/modules/account/errors.py
@@ -4,24 +4,24 @@ from modules.error.custom_errors import AppError
 
 class AccountWithUserNameExistsError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccountErrorCode.USERNAME_ALREADY_EXISTS, https_status_code=409, message=message)
+        super().__init__(code=AccountErrorCode.USERNAME_ALREADY_EXISTS, http_status_code=409, message=message)
 
 
 class AccountNotFoundError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccountErrorCode.NOT_FOUND, https_status_code=404, message=message)
+        super().__init__(code=AccountErrorCode.NOT_FOUND, http_status_code=404, message=message)
 
 
 class AccountInvalidPasswordError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccountErrorCode.INVALID_CREDENTIALS, https_status_code=401, message=message)
+        super().__init__(code=AccountErrorCode.INVALID_CREDENTIALS, http_status_code=401, message=message)
 
 
 class AccountBadRequestError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccountErrorCode.BAD_REQUEST, https_status_code=400, message=message)
+        super().__init__(code=AccountErrorCode.BAD_REQUEST, http_status_code=400, message=message)
 
 
 class AccountWithPhoneNumberExistsError(AppError):
     def __init__(self, message: str) -> None:
-        super().__init__(code=AccountErrorCode.PHONE_NUMBER_ALREADY_EXISTS, https_status_code=409, message=message)
+        super().__init__(code=AccountErrorCode.PHONE_NUMBER_ALREADY_EXISTS, http_status_code=409, message=message)

--- a/src/apps/backend/modules/communication/errors.py
+++ b/src/apps/backend/modules/communication/errors.py
@@ -13,7 +13,7 @@ class ValidationError(AppError):
         self.code = CommunicationErrorCode.VALIDATION_ERROR
         super().__init__(message=msg, code=self.code)
         self.failures = failures
-        self.https_code = 400
+        self.http_code = 400
 
 
 class ServiceError(AppError):

--- a/src/apps/backend/modules/error/custom_errors.py
+++ b/src/apps/backend/modules/error/custom_errors.py
@@ -2,10 +2,10 @@ from typing import Any, Optional
 
 
 class AppError(Exception):
-    def __init__(self, message: str, code: str, https_status_code: Optional[int] = None) -> None:
+    def __init__(self, message: str, code: str, http_status_code: Optional[int] = None) -> None:
         self.message = message
         self.code = code
-        self.https_code = https_status_code
+        self.http_code = http_status_code
         super().__init__(self.message)
 
     def to_str(self) -> str:
@@ -15,7 +15,7 @@ class AppError(Exception):
         error_dict = {
             "message": self.message,
             "code": self.code,
-            "https_code": self.https_code,
+            "http_code": self.http_code,
             "args": self.args,
             "with_traceback": self.with_traceback,
         }

--- a/src/apps/backend/modules/otp/errors.py
+++ b/src/apps/backend/modules/otp/errors.py
@@ -5,7 +5,7 @@ from modules.otp.types import OtpErrorCode
 class OtpIncorrectError(AppError):
     def __init__(self) -> None:
         super().__init__(
-            code=OtpErrorCode.INCORRECT_OTP, https_status_code=400, message="Please provide the correct OTP to login."
+            code=OtpErrorCode.INCORRECT_OTP, http_status_code=400, message="Please provide the correct OTP to login."
         )
 
 
@@ -13,7 +13,7 @@ class OtpExpiredError(AppError):
     def __init__(self) -> None:
         super().__init__(
             code=OtpErrorCode.OTP_EXPIRED,
-            https_status_code=400,
+            http_status_code=400,
             message="The OTP has expired. Please request a new OTP.",
         )
 
@@ -21,5 +21,5 @@ class OtpExpiredError(AppError):
 class OtpRequestFailedError(AppError):
     def __init__(self) -> None:
         super().__init__(
-            code=OtpErrorCode.REQUEST_FAILED, https_status_code=400, message="Please provide a valid phone number."
+            code=OtpErrorCode.REQUEST_FAILED, http_status_code=400, message="Please provide a valid phone number."
         )

--- a/src/apps/backend/modules/password_reset_token/errors.py
+++ b/src/apps/backend/modules/password_reset_token/errors.py
@@ -7,6 +7,6 @@ class PasswordResetTokenNotFoundError(AppError):
     def __init__(self) -> None:
         super().__init__(
             code=PasswordResetTokenErrorCode.PASSWORD_RESET_TOKEN_NOT_FOUND,
-            https_status_code=404,
+            http_status_code=404,
             message=f"System is unable to find a token with this account",
         )

--- a/src/apps/backend/server.py
+++ b/src/apps/backend/server.py
@@ -40,4 +40,4 @@ app.register_blueprint(react_blueprint)
 
 @app.errorhandler(AppError)
 def handle_error(exc: AppError) -> ResponseReturnValue:
-    return jsonify({"message": exc.message, "code": exc.code}), exc.https_code or 500
+    return jsonify({"message": exc.message, "code": exc.code}), exc.http_code or 500


### PR DESCRIPTION
## Description
This PR is raised to refactor AppService by renaming all instances of `https_status_code` to `http_status_code` in AppError

Reason for the change:
- The term "HTTP" (HyperText Transfer Protocol) is more commonly used across web technologies, and the status codes returned by HTTP servers are referred to as HTTP status codes (e.g., 200 OK, 404 Not Found). Changing https_status_code to http_status_code ensures consistency with this established terminology.

## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- Created a new user using username and password and verified document generation
- Created a new user using phone number and otp and verified document generation
- Login using username credentials
- Login using phone number and otp
- When entering invalid otp raised `Http error 400 Bad Request` raised with `"code":"OTP_ERR_01" `invalid otp
- When entering expired otp raised `Http error 400 Bad Request` raised with `"code":"OTP_ERR_02" `expired otp
- When entering wrong email results in `Http error 404 Not Found` raised with `"code":"ACCOUNT_ERR_02"` account not found
- When entering wrong password results in `Http error 403 Unauthorized` with code `"code":"ACCOUNT_ERR_02"` invalid password
- When entering wrong mail in forget password results in `Http error 404 Not Found` raised with `"code":"ACCOUNT_ERR_02" `account not found
- Entering existing mail in signup lead to `Http error 409 confict` raised with `"code":"ACCOUNT_ERR_01"` Account already exists