### PR TITLE
Fix: Refactor to return ApiResponse<AccessToken> in login & OTP services

### DIFF
--- a/src/apps/backend/modules/access_token/access_token_service.py
+++ b/src/apps/backend/modules/access_token/access_token_service.py
@@ -42,9 +42,10 @@ class AccessTokenService:
     def __generate_access_token(*, account: Account) -> AccessToken:
         jwt_signing_key = ConfigService.get_token_signing_key()
         jwt_expiry = timedelta(days=ConfigService.get_token_expiry_days())
-        payload = {"account_id": account.id, "exp": (datetime.now() + jwt_expiry).timestamp()}
+        expiry_time = datetime.now() + jwt_expiry
+        payload = {"account_id": account.id, "exp": (expiry_time).timestamp()}
         jwt_token = jwt.encode(payload, jwt_signing_key, algorithm="HS256")
-        access_token = AccessToken(token=jwt_token, account_id=account.id, expires_at=str(payload["exp"]))
+        access_token = AccessToken(token=jwt_token, account_id=account.id, expires_at=expiry_time.isoformat())
 
         return access_token
 

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -40,12 +40,23 @@ const signupFn = async (
   lastName: string,
   username: string,
   password: string,
-): Promise<ApiResponse<void>> => authService.signup(firstName, lastName, username, password);
+): Promise<ApiResponse<void>> =>
+  authService.signup(firstName, lastName, username, password);
 
 const loginFn = async (
   username: string,
   password: string,
-): Promise<ApiResponse<AccessToken>> => authService.login(username, password);
+): Promise<ApiResponse<AccessToken>> => {
+  const result = await authService.login(username, password);
+  if (result.data) {
+    localStorage.setItem('access-token', JSON.stringify({
+      account_id:result.data.accountId,
+      expires_at:result.data.expiresAt,
+      token:result.data.token
+    }));
+  }
+  return result;
+};
 
 const logoutFn = (): void => localStorage.removeItem('access-token');
 
@@ -61,8 +72,17 @@ const sendOTPFn = async (
 const verifyOTPFn = async (
   phoneNumber: PhoneNumber,
   otp: string,
-): Promise<ApiResponse<AccessToken>> => authService.verifyOTP(phoneNumber, otp);
- 
+): Promise<ApiResponse<AccessToken>> => {
+  const result = await authService.verifyOTP(phoneNumber, otp);
+  if (result.data) {
+    localStorage.setItem('access-token', JSON.stringify({
+      account_id:result.data.accountId,
+      expires_at:result.data.expiresAt,
+      token:result.data.token
+    }));
+  }
+  return result;
+};
 
 export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const {

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -49,11 +49,7 @@ const loginFn = async (
 ): Promise<ApiResponse<AccessToken>> => {
   const result = await authService.login(username, password);
   if (result.data) {
-    localStorage.setItem('access-token', JSON.stringify({
-      account_id:result.data.accountId,
-      expires_at:result.data.expiresAt,
-      token:result.data.token
-    }));
+    localStorage.setItem('access-token', JSON.stringify(result.data.toJson()));
   }
   return result;
 };
@@ -75,11 +71,7 @@ const verifyOTPFn = async (
 ): Promise<ApiResponse<AccessToken>> => {
   const result = await authService.verifyOTP(phoneNumber, otp);
   if (result.data) {
-    localStorage.setItem('access-token', JSON.stringify({
-      account_id:result.data.accountId,
-      expires_at:result.data.expiresAt,
-      token:result.data.token
-    }));
+    localStorage.setItem('access-token', JSON.stringify(result.data.toJson()));
   }
   return result;
 };

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -40,19 +40,12 @@ const signupFn = async (
   lastName: string,
   username: string,
   password: string,
-): Promise<ApiResponse<void>> =>
-  authService.signup(firstName, lastName, username, password);
+): Promise<ApiResponse<void>> => authService.signup(firstName, lastName, username, password);
 
 const loginFn = async (
   username: string,
   password: string,
-): Promise<ApiResponse<AccessToken>> => {
-  const result = await authService.login(username, password);
-  if (result.data) {
-    localStorage.setItem('access-token', JSON.stringify(result.data));
-  }
-  return result;
-};
+): Promise<ApiResponse<AccessToken>> => authService.login(username, password);
 
 const logoutFn = (): void => localStorage.removeItem('access-token');
 
@@ -68,13 +61,8 @@ const sendOTPFn = async (
 const verifyOTPFn = async (
   phoneNumber: PhoneNumber,
   otp: string,
-): Promise<ApiResponse<AccessToken>> => {
-  const result = await authService.verifyOTP(phoneNumber, otp);
-  if (result.data) {
-    localStorage.setItem('access-token', JSON.stringify(result.data));
-  }
-  return result;
-};
+): Promise<ApiResponse<AccessToken>> => authService.verifyOTP(phoneNumber, otp);
+ 
 
 export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const {

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -20,15 +20,12 @@ export default class AuthService extends APIService {
   login = async (
     username: string,
     password: string,
-  ): Promise<ApiResponse<AccessToken>> => {
-      const response = await this.apiClient.post('/access-tokens', {
-        username,
-        password,
-      });
-      if (response.data) {
-        localStorage.setItem('access-token', JSON.stringify(response.data));
-      }
-      return new ApiResponse(new AccessToken(response.data as JsonObject));
+  ): Promise<ApiResponse<AccessToken>> =>{
+    const response = await this.apiClient.post('/access-tokens', {
+      username,
+      password,
+    });
+    return new ApiResponse(new AccessToken(response.data as JsonObject))
   }
 
   sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<void>> =>
@@ -42,17 +39,15 @@ export default class AuthService extends APIService {
   verifyOTP = async (
     phoneNumber: PhoneNumber,
     otp: string,
-  ): Promise<ApiResponse<AccessToken>> => {
-      const response = await this.apiClient.post('/access-tokens', {
-        phone_number: {
-          country_code: phoneNumber.countryCode,
-          phone_number: phoneNumber.phoneNumber,
-        },
-        otp_code: otp,
-      });
-      if (response.data) {
-        localStorage.setItem('access-token', JSON.stringify(response.data));
-      }
-      return new ApiResponse(new AccessToken(response.data as JsonObject));
-    }
+  ): Promise<ApiResponse<AccessToken>> =>
+  {
+    const response = await this.apiClient.post('/access-tokens', {
+      phone_number: {
+        country_code: phoneNumber.countryCode,
+        phone_number: phoneNumber.phoneNumber,
+      },
+      otp_code: otp,
+    });
+    return new ApiResponse(new AccessToken(response.data as JsonObject))  
+  }
 }

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -21,11 +21,11 @@ export default class AuthService extends APIService {
     username: string,
     password: string,
   ): Promise<ApiResponse<AccessToken>> =>{
-    const response = await this.apiClient.post('/access-tokens', {
+    const response = await this.apiClient.post<JsonObject>('/access-tokens', {
       username,
       password,
     });
-    return new ApiResponse(new AccessToken(response.data as JsonObject))
+    return new ApiResponse(new AccessToken(response.data))
   }
 
   sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<void>> =>
@@ -41,13 +41,13 @@ export default class AuthService extends APIService {
     otp: string,
   ): Promise<ApiResponse<AccessToken>> =>
   {
-    const response = await this.apiClient.post('/access-tokens', {
+    const response = await this.apiClient.post<JsonObject>('/access-tokens', {
       phone_number: {
         country_code: phoneNumber.countryCode,
         phone_number: phoneNumber.phoneNumber,
       },
       otp_code: otp,
     });
-    return new ApiResponse(new AccessToken(response.data as JsonObject))  
+    return new ApiResponse(new AccessToken(response.data))  
   }
 }

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -1,4 +1,5 @@
 import { AccessToken, ApiResponse, PhoneNumber } from '../types';
+import { JsonObject } from '../types/common-types';
 
 import APIService from './api.service';
 
@@ -19,11 +20,16 @@ export default class AuthService extends APIService {
   login = async (
     username: string,
     password: string,
-  ): Promise<ApiResponse<AccessToken>> =>
-    this.apiClient.post('/access-tokens', {
-      username,
-      password,
-    });
+  ): Promise<ApiResponse<AccessToken>> => {
+      const response = await this.apiClient.post('/access-tokens', {
+        username,
+        password,
+      });
+      if (response.data) {
+        localStorage.setItem('access-token', JSON.stringify(response.data));
+      }
+      return new ApiResponse(new AccessToken(response.data as JsonObject));
+  }
 
   sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<void>> =>
     this.apiClient.post('/accounts', {
@@ -36,12 +42,17 @@ export default class AuthService extends APIService {
   verifyOTP = async (
     phoneNumber: PhoneNumber,
     otp: string,
-  ): Promise<ApiResponse<AccessToken>> =>
-    this.apiClient.post('/access-tokens', {
-      phone_number: {
-        country_code: phoneNumber.countryCode,
-        phone_number: phoneNumber.phoneNumber,
-      },
-      otp_code: otp,
-    });
+  ): Promise<ApiResponse<AccessToken>> => {
+      const response = await this.apiClient.post('/access-tokens', {
+        phone_number: {
+          country_code: phoneNumber.countryCode,
+          phone_number: phoneNumber.phoneNumber,
+        },
+        otp_code: otp,
+      });
+      if (response.data) {
+        localStorage.setItem('access-token', JSON.stringify(response.data));
+      }
+      return new ApiResponse(new AccessToken(response.data as JsonObject));
+    }
 }

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -3,12 +3,22 @@ import { JsonObject } from './common-types';
 export class AccessToken {
   accountId: string;
   token: string;
-  expiresAt:string
+  expiresAt:Date;
 
   constructor(json: JsonObject) {
     this.accountId = json.account_id as string;
     this.token = json.token as string;
-    this.expiresAt = json.expires_at as string;
+    // Convert from Unix timestamp (seconds) to Date object
+    this.expiresAt = new Date(parseFloat(json.expires_at as string) * 1000);
+  }
+  
+  toJson(): JsonObject { 
+    return{ 
+      account_id:this.accountId,
+      // Convert Date object back to Unix timestamp (seconds)
+      expires_at:(this.expiresAt.getTime()/1000).toString(),
+      token:this.token 
+    }
   }
 }
 export enum KeyboardKeys {

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -3,10 +3,12 @@ import { JsonObject } from './common-types';
 export class AccessToken {
   accountId: string;
   token: string;
+  expiresAt:string
 
   constructor(json: JsonObject) {
     this.accountId = json.account_id as string;
     this.token = json.token as string;
+    this.expiresAt = json.expires_at as string;
   }
 }
 export enum KeyboardKeys {

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -3,24 +3,23 @@ import { JsonObject } from './common-types';
 export class AccessToken {
   accountId: string;
   token: string;
-  expiresAt:Date;
+  expiresAt: Date;
 
   constructor(json: JsonObject) {
     this.accountId = json.account_id as string;
     this.token = json.token as string;
-    // Convert from Unix timestamp (seconds) to Date object
-    this.expiresAt = new Date(parseFloat(json.expires_at as string) * 1000);
+    this.expiresAt = json.expires_at as Date;
   }
-  
+
   toJson(): JsonObject { 
-    return{ 
-      account_id:this.accountId,
-      // Convert Date object back to Unix timestamp (seconds)
-      expires_at:(this.expiresAt.getTime()/1000).toString(),
-      token:this.token 
-    }
+    return { 
+      account_id: this.accountId,
+      token: this.token,
+      expires_at:this.expiresAt 
+    };
   }
 }
+
 export enum KeyboardKeys {
   BACKSPACE = 'Backspace',
 }


### PR DESCRIPTION
## Description
This PR refactors the login and OTP verification processes to ensure both consistently return `ApiResponse<AccessToken>` objects. This enhances the reliability of the authentication flow and aligns with organizational standards.

### Reason for the Change
The functions were specified to return `ApiResponse<AccessToken>` objects but were actually returning JSON objects. Functions must adheres to strict type scrutiny.

### Changes

- Formatted date response from API to use ISO 8601 format for consistency with industry standards.
- Updated service to return ApiResponse<AccessToken> objects.
- Added expiresAt field to AccessToken class.

## Database Schema Changes
_None_

## Tests
### Automated Test Cases Added
_None_

### Manual Test Cases Run
User Creation: Verified document generation when creating a user using both username/password and phone number/OTP.

Login:

- Verified login functionality using username credentials.
- Verified login using phone number and OTP.

OTP Errors:

- Test for invalid OTP raised HTTP error 400 ("code": "OTP_ERR_01" invalid otp).
- Test for expired OTP raised HTTP error 400 ("code": "OTP_ERR_02" expired otp).

Account Errors:

- Test for incorrect email during login raised HTTP error 404 ("code": "ACCOUNT_ERR_02" account not found) with toast.
- Test for incorrect password during login raised HTTP error 403 ("code": "ACCOUNT_ERR_02" invalid password) with toast.
- Test for incorrect email during forget password raised HTTP error 404 ("code": "ACCOUNT_ERR_02" account not found) with toast.
- Test for existing email during signup raised HTTP error 409 ("code": "ACCOUNT_ERR_01" Account already exists) with toast.