### PR TITLE
fix(husky): do not stage all files from index

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 npm run fmt
-git add .


### PR DESCRIPTION
## Description
The current setup makes it such that whenever a commit is made, husky will go ahead and add all changes to staging as a part of the pre-commit hook, regardless of whether the user selected a particular set of files. This effectively removes the ability to cherry-pick files and push those only. Currently, the only possible solution is to branch out for every single change, which may quickly become cumbersome especially if multiple versions of a single change are being tested simultaneously. 

This PR addresses that issue, especially when users might not want to push files associated with an unfinished change.

In other words, pre-commit should only be run on user-staged files.

## Database schema changes
N/A

## Tests
### Automated test cases added
N/A

### Manual test cases run
N/A