### PR TITLE
fix(storage-util): resolve conflicting access token storage format

### DIFF
--- a/src/apps/frontend/utils/storage-util.ts
+++ b/src/apps/frontend/utils/storage-util.ts
@@ -12,7 +12,7 @@ export const getAccessTokenFromStorage = (): Nullable<AccessToken> => {
 };
 
 export const setAccessTokenToStorage = (token: AccessToken): void => {
-  localStorage.setItem(ACCESS_TOKEN_KEY, JSON.stringify(token));
+  localStorage.setItem(ACCESS_TOKEN_KEY, JSON.stringify(token.toJson()));
 };
 
 export const removeAccessTokenFromStorage = (): void => {


### PR DESCRIPTION
## Description

#100 added a new token serialization mechanism for local storage, which effectively got reverted by #83. For more info, check the commit history of https://github.com/jalantechnologies/rflask-boilerplate/blob/main/src/apps/frontend/contexts/auth.provider.tsx#L67

This PR addresses that issue to ensure compatible formats while the JSON data is serialized for local storage and later fetched from there. 

## Tests
### Manual test cases run

- Checked the authentication flow and it is working as expected again. 
