### PR TITLE
[WIP]chore: Enhance OTP System for Specific Scenarios

### DIFF
--- a/src/apps/backend/modules/account/account_service.py
+++ b/src/apps/backend/modules/account/account_service.py
@@ -36,7 +36,7 @@ class AccountService:
         create_otp_params = CreateOtpParams(phone_number=params.phone_number)
         otp = OtpService.create_otp(params=create_otp_params)
         
-        otp_to_return = otp if os.environ.get("APP_ENV", "development") != "production" else None
+        otp_to_return = otp if os.environ.get("APP_ENV", "development") not in ["production", "preview"] else None
         
         return account, otp_to_return
 

--- a/src/apps/backend/modules/account/rest_api/account_view.py
+++ b/src/apps/backend/modules/account/rest_api/account_view.py
@@ -27,7 +27,7 @@ class AccountView(MethodView):
             account, otp = AccountService.get_or_create_account_by_phone_number(params=account_params)
             account_dict = asdict(account)
             if otp:
-                account_dict["otp"] = otp.otp_code
+                account_dict["otp_code"] = otp.otp_code
         elif "username" in request_data and "password" in request_data:
             account_params = CreateAccountByUsernameAndPasswordParams(**request_data)
             account = AccountService.create_account_by_username_and_password(params=account_params)

--- a/src/apps/backend/modules/account/rest_api/account_view.py
+++ b/src/apps/backend/modules/account/rest_api/account_view.py
@@ -24,11 +24,14 @@ class AccountView(MethodView):
             phone_number_data = request_data["phone_number"]
             phone_number_obj = PhoneNumber(**phone_number_data)
             account_params = CreateAccountByPhoneNumberParams(phone_number=phone_number_obj)
-            account = AccountService.get_or_create_account_by_phone_number(params=account_params)
+            account, otp = AccountService.get_or_create_account_by_phone_number(params=account_params)
+            account_dict = asdict(account)
+            if otp:
+                account_dict["otp"] = otp.otp_code
         elif "username" in request_data and "password" in request_data:
             account_params = CreateAccountByUsernameAndPasswordParams(**request_data)
             account = AccountService.create_account_by_username_and_password(params=account_params)
-        account_dict = asdict(account)
+            account_dict = asdict(account)
         return jsonify(account_dict), 201
 
     @access_auth_middleware

--- a/src/apps/backend/modules/config/config_service.py
+++ b/src/apps/backend/modules/config/config_service.py
@@ -47,6 +47,14 @@ class ConfigService:
         return DictUtil.required_get_str(input_dict=ConfigManager.config, key="WEB_APP_HOST")
 
     @staticmethod
+    def get_default_otp_enabled() -> bool:
+        return DictUtil.required_get_bool(input_dict=ConfigManager.config, key="DEFAULT_OTP_ENABLED")
+
+    @staticmethod
+    def get_default_otp() -> str:
+        return DictUtil.required_get_str(input_dict=ConfigManager.config, key="DEFAULT_OTP")
+    
+    @staticmethod
     def get_sendgrid_api_key() -> str:
         return str(DictUtil.required_get_dict(input_dict=ConfigManager.config, key="SENDGRID")["api_key"])
 

--- a/src/apps/backend/modules/config/config_service.py
+++ b/src/apps/backend/modules/config/config_service.py
@@ -79,7 +79,7 @@ class ConfigService:
         return key in ConfigManager.config
 
     @staticmethod
-    def has_default_phone_number() -> bool:
-        if ConfigService.has_key("OTP") and "default_phone_number" in ConfigManager.config["OTP"]:
+    def has_exempt_phone_number() -> bool:
+        if ConfigService.has_key("OTP") and "exempt_phone_number" in ConfigManager.config["OTP"]:
             return True
         return False

--- a/src/apps/backend/modules/otp/internal/otp_util.py
+++ b/src/apps/backend/modules/otp/internal/otp_util.py
@@ -21,6 +21,8 @@ class OtpUtil:
     def generate_otp(length: int, phone_number: str) -> str:
         if OtpUtil.is_default_phone_number(phone_number):
             return ConfigService.get_otp_config("default_otp")
+        if OtpUtil.is_default_otp_enabled():
+            return ConfigService.get_default_otp()
         return "".join(random.choices(string.digits, k=length))
 
     @staticmethod
@@ -32,3 +34,9 @@ class OtpUtil:
             phone_number=validated_otp_data.phone_number,
             status=validated_otp_data.status,
         )
+
+    @staticmethod
+    def is_default_otp_enabled() -> bool:
+        if ConfigService.has_key("DEFAULT_OTP_ENABLED"):
+            return ConfigService.get_default_otp_enabled()
+        return False

--- a/src/apps/backend/modules/otp/internal/otp_util.py
+++ b/src/apps/backend/modules/otp/internal/otp_util.py
@@ -9,18 +9,18 @@ from modules.otp.types import Otp
 
 class OtpUtil:
     @staticmethod
-    def is_default_phone_number(phone_number: str) -> bool:
-        default_phone_number = None
-        if ConfigService.has_default_phone_number():
-            default_phone_number = ConfigService.get_otp_config("default_phone_number")
-            if default_phone_number and phone_number == default_phone_number:
+    def is_exempt_phone_number(phone_number: str) -> bool:
+        exempt_phone_number = None
+        if ConfigService.has_exempt_phone_number():
+            exempt_phone_number = ConfigService.get_otp_config("exempt_phone_number")
+            if exempt_phone_number and phone_number == exempt_phone_number:
                 return True
         return False
 
     @staticmethod
     def generate_otp(length: int, phone_number: str) -> str:
-        if OtpUtil.is_default_phone_number(phone_number):
-            return ConfigService.get_otp_config("default_otp")
+        if OtpUtil.is_exempt_phone_number(phone_number):
+            return ConfigService.get_otp_config("exempt_otp")
         if OtpUtil.is_default_otp_enabled():
             return ConfigService.get_default_otp()
         return "".join(random.choices(string.digits, k=length))

--- a/src/apps/backend/modules/otp/otp_service.py
+++ b/src/apps/backend/modules/otp/otp_service.py
@@ -18,7 +18,10 @@ class OtpService:
             message_body=f"{otp.otp_code} is your One Time Password (OTP) for verification.",
             recipient_phone=recipient_phone_number,
         )
-        if not OtpUtil.is_default_phone_number(phone_number=recipient_phone_number.phone_number):
+        if (
+            not OtpUtil.is_default_phone_number(phone_number=recipient_phone_number.phone_number)
+            and not OtpUtil.is_default_otp_enabled()
+        ):
             SMSService.send_sms(params=send_sms_params)
 
         return otp

--- a/src/apps/backend/modules/otp/otp_service.py
+++ b/src/apps/backend/modules/otp/otp_service.py
@@ -19,7 +19,7 @@ class OtpService:
             recipient_phone=recipient_phone_number,
         )
         if (
-            not OtpUtil.is_default_phone_number(phone_number=recipient_phone_number.phone_number)
+            not OtpUtil.is_exempt_phone_number(phone_number=recipient_phone_number.phone_number)
             and not OtpUtil.is_default_otp_enabled()
         ):
             SMSService.send_sms(params=send_sms_params)

--- a/src/apps/backend/settings/development.py
+++ b/src/apps/backend/settings/development.py
@@ -7,6 +7,8 @@ class DevelopmentSettings:
     MONGODB_URI: str = "mongodb://localhost:27017/frm-boilerplate-dev"
     SMS_ENABLED: bool = False
     IS_SERVER_RUNNING_BEHIND_PROXY: bool = True
+    DEFAULT_OTP_ENABLED : bool = True
+    DEFAULT_OTP : str = "6666"
 
 
 @dataclass(frozen=True)
@@ -15,3 +17,5 @@ class DockerInstanceDevelopmentSettings:
     MONGODB_URI: str = "mongodb://db:27017/frm-boilerplate-dev"
     SMS_ENABLED: bool = False
     IS_SERVER_RUNNING_BEHIND_PROXY: bool = True
+    DEFAULT_OTP_ENABLED : bool = True
+    DEFAULT_OTP : str = "6666"

--- a/src/apps/backend/settings/os_envs.py
+++ b/src/apps/backend/settings/os_envs.py
@@ -19,8 +19,8 @@ class OSSettings:
     )
     OTP: Optional[dict[str, Optional[str]]] = field(
         default_factory=lambda: {
-            "default_phone_number": os.environ.get("DEFAULT_PHONE_NUMBER"),
-            "default_otp": os.environ.get("DEFAULT_OTP"),
+            "exempt_phone_number": os.environ.get("EXEMPT_PHONE_NUMBER"),
+            "exempt_otp": os.environ.get("EXEMPT_OTP"),
         }
     )
     TWILIO: Optional[dict[str, Optional[str]]] = field(

--- a/src/apps/backend/settings/preview.py
+++ b/src/apps/backend/settings/preview.py
@@ -6,5 +6,5 @@ class PreviewSettings:
     LOGGER_TRANSPORTS: tuple[str, str] = ("console", "datadog")
     SMS_ENABLED: bool = True
     IS_SERVER_RUNNING_BEHIND_PROXY: bool = True
-    DEFAULT_OTP_ENABLED : bool = True
+    DEFAULT_OTP_ENABLED : bool = False
     DEFAULT_OTP : str = "6666"

--- a/src/apps/backend/settings/preview.py
+++ b/src/apps/backend/settings/preview.py
@@ -6,3 +6,5 @@ class PreviewSettings:
     LOGGER_TRANSPORTS: tuple[str, str] = ("console", "datadog")
     SMS_ENABLED: bool = True
     IS_SERVER_RUNNING_BEHIND_PROXY: bool = True
+    DEFAULT_OTP_ENABLED : bool = True
+    DEFAULT_OTP : str = "6666"

--- a/src/apps/backend/settings/testing.py
+++ b/src/apps/backend/settings/testing.py
@@ -12,6 +12,12 @@ class TestingSettings:
         }
     )
     SMS_ENABLED: bool = False
+    OTP: dict[str, str] = field(
+        default_factory=lambda: {
+            "exempt_phone_number": "1234567890",
+            "exempt_otp": "1234",
+        }
+    )
 
 
 @dataclass(frozen=True)
@@ -25,3 +31,9 @@ class DockerInstanceTestingSettings:
         }
     )
     SMS_ENABLED: bool = False
+    OTP: dict[str, str] = field(
+        default_factory=lambda: {
+            "exempt_phone_number": "1234567890",
+            "exempt_otp": "1234",
+        }
+    )

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 
 import { AuthService } from '../services';
-import { AccessToken, ApiResponse, AsyncError, OTP, PhoneNumber } from '../types';
+import { AccessToken, ApiResponse, AsyncError, OTPCode, PhoneNumber } from '../types';
 import { Nullable } from '../types/common-types';
 import {
   getAccessTokenFromStorage,
@@ -26,8 +26,9 @@ type AuthContextType = {
   loginError: Nullable<AsyncError>;
   loginResult: Nullable<AccessToken>;
   logout: () => void;
-  sendOTP: (phoneNumber: PhoneNumber) => Promise<Nullable<OTP>>;
+  sendOTP: (phoneNumber: PhoneNumber) => Promise<Nullable<OTPCode>>;
   sendOTPError: Nullable<AsyncError>;
+  sendOTPResult: Nullable<OTPCode>;
   signup: (
     firstName: string,
     lastName: string,
@@ -75,7 +76,7 @@ const isUserAuthenticated = () => !!getAccessTokenFromStorage();
 
 const sendOTPFn = async (
   phoneNumber: PhoneNumber,
-): Promise<ApiResponse<OTP>> => authService.sendOTP(phoneNumber);
+): Promise<ApiResponse<OTPCode>> => authService.sendOTP(phoneNumber);
 
 const verifyOTPFn = async (
   phoneNumber: PhoneNumber,
@@ -108,6 +109,7 @@ export const AuthProvider: React.FC<PropsWithChildren<ReactNode>> = ({
     isLoading: isSendOTPLoading,
     error: sendOTPError,
     asyncCallback: sendOTP,
+    result: sendOTPResult,
   } = useAsync(sendOTPFn);
 
   const {
@@ -131,6 +133,7 @@ export const AuthProvider: React.FC<PropsWithChildren<ReactNode>> = ({
         logout: logoutFn,
         sendOTP,
         sendOTPError,
+        sendOTPResult,
         signup,
         signupError,
         verifyOTP,

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 
 import { AuthService } from '../services';
-import { AccessToken, ApiResponse, AsyncError, PhoneNumber } from '../types';
+import { AccessToken, ApiResponse, AsyncError, OTP, PhoneNumber } from '../types';
 import { Nullable } from '../types/common-types';
 import {
   getAccessTokenFromStorage,
@@ -26,7 +26,7 @@ type AuthContextType = {
   loginError: Nullable<AsyncError>;
   loginResult: Nullable<AccessToken>;
   logout: () => void;
-  sendOTP: (phoneNumber: PhoneNumber) => Promise<Nullable<void>>;
+  sendOTP: (phoneNumber: PhoneNumber) => Promise<Nullable<OTP>>;
   sendOTPError: Nullable<AsyncError>;
   signup: (
     firstName: string,
@@ -75,7 +75,7 @@ const isUserAuthenticated = () => !!getAccessTokenFromStorage();
 
 const sendOTPFn = async (
   phoneNumber: PhoneNumber,
-): Promise<ApiResponse<void>> => authService.sendOTP(phoneNumber);
+): Promise<ApiResponse<OTP>> => authService.sendOTP(phoneNumber);
 
 const verifyOTPFn = async (
   phoneNumber: PhoneNumber,

--- a/src/apps/frontend/pages/authentication/otp/index.tsx
+++ b/src/apps/frontend/pages/authentication/otp/index.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button, H2, VerticalStackLayout } from '../../../components';
 import constant from '../../../constants';
 import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
+import { AsyncError, OTPCode } from '../../../types';
 import { ButtonKind } from '../../../types/button';
 import useTimer from '../../../utils/use-timer.hook';
 import AuthenticationFormLayout from '../authentication-form-layout';
@@ -24,11 +24,14 @@ export const OTPPage: React.FC = () => {
     navigate(routes.DASHBOARD);
   };
 
-  const onResendOTPSuccess = () => {
+  const onResendOTPSuccess = (otp: OTPCode) => {
     startTimer();
-    toast.success(
-      'OTP has been successfully re-sent. Please check your messages.',
-    );
+    const baseMessage = "OTP has been re-sent successfully. Please check your messages.";
+    const message = otp.otpCode
+      ? `${baseMessage} OTP Code: ${otp.otpCode}`
+      : baseMessage;
+
+    toast.success(message);
   };
 
   const onError = (error: AsyncError) => {

--- a/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
+++ b/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
@@ -3,11 +3,11 @@ import * as Yup from 'yup';
 
 import constant from '../../../constants';
 import { useAuthContext } from '../../../contexts';
-import { AsyncError, PhoneNumber } from '../../../types';
+import { AsyncError, OTPCode, PhoneNumber } from '../../../types';
 
 interface OTPFormProps {
   onError: (error: AsyncError) => void;
-  onResendOTPSuccess: () => void;
+  onResendOTPSuccess: (otp: OTPCode) => void;
   onVerifyOTPSuccess: () => void;
 }
 
@@ -65,8 +65,8 @@ const useOTPForm = ({
         phone_number: phoneNumber,
       }),
     )
-      .then(() => {
-        onResendOTPSuccess();
+      .then((otp) => {
+        onResendOTPSuccess(otp as OTPCode);
       })
       .catch((error) => {
         onError(error as AsyncError);

--- a/src/apps/frontend/pages/authentication/otp/otp-form.tsx
+++ b/src/apps/frontend/pages/authentication/otp/otp-form.tsx
@@ -9,7 +9,7 @@ import {
   VerticalStackLayout,
 } from '../../../components';
 import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
+import { AsyncError, OTPCode } from '../../../types';
 import { ButtonKind, ButtonType } from '../../../types/button';
 
 import useOTPForm from './otp-form-hook';
@@ -17,7 +17,7 @@ import useOTPForm from './otp-form-hook';
 interface OTPFormProps {
   isResendEnabled: boolean;
   onError: (error: AsyncError) => void;
-  onResendOTPSuccess: () => void;
+  onResendOTPSuccess: (otp: OTPCode) => void;
   onVerifyOTPSuccess: () => void;
   timerRemainingSeconds: string;
 }

--- a/src/apps/frontend/pages/authentication/phone-login/index.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/index.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import toast from 'react-hot-toast';
 
 import { H2, VerticalStackLayout } from '../../../components';
-import { AsyncError } from '../../../types';
+import { AsyncError, OTP } from '../../../types';
 import AuthenticationFormLayout from '../authentication-form-layout';
 import AuthenticationPageLayout from '../authentication-page-layout';
 
 import PhoneLoginForm from './phone-login-form';
 
 export const PhoneLogin: React.FC = () => {
-  const onSendOTPSuccess = () => {
-    toast.success(
-      'OTP has been sent successfully. Please check your messages.',
-    );
+  const onSendOTPSuccess = (otp: OTP) => {
+    const baseMessage = "OTP has been sent successfully. Please check your messages.";
+    const message = otp.otpCode
+      ? `${baseMessage} OTP Code: ${otp.otpCode}`
+      : baseMessage;
+
+    toast.success(message);
   };
 
   const onError = (error: AsyncError) => {

--- a/src/apps/frontend/pages/authentication/phone-login/index.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/index.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import toast from 'react-hot-toast';
 
 import { H2, VerticalStackLayout } from '../../../components';
-import { AsyncError, OTP } from '../../../types';
+import { AsyncError, OTPCode } from '../../../types';
 import AuthenticationFormLayout from '../authentication-form-layout';
 import AuthenticationPageLayout from '../authentication-page-layout';
 
 import PhoneLoginForm from './phone-login-form';
 
 export const PhoneLogin: React.FC = () => {
-  const onSendOTPSuccess = (otp: OTP) => {
+  const onSendOTPSuccess = (otp: OTPCode) => {
     const baseMessage = "OTP has been sent successfully. Please check your messages.";
     const message = otp.otpCode
       ? `${baseMessage} OTP Code: ${otp.otpCode}`

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
@@ -6,18 +6,18 @@ import * as Yup from 'yup';
 import constant from '../../../constants';
 import routes from '../../../constants/routes';
 import { useAuthContext } from '../../../contexts';
-import { AsyncError, OTP, PhoneNumber } from '../../../types';
+import { AsyncError, OTPCode, PhoneNumber } from '../../../types';
 
 interface PhoneLoginFormProps {
   onError: (err: AsyncError) => void;
-  onSendOTPSuccess: (otp: OTP) => void;
+  onSendOTPSuccess: (otp: OTPCode) => void;
 }
 
 const usePhoneLoginForm = ({
   onSendOTPSuccess,
   onError,
 }: PhoneLoginFormProps) => {
-  const { isSendOTPLoading, sendOTPError, sendOTP } = useAuthContext();
+  const { isSendOTPLoading, sendOTPError, sendOTP, sendOTPResult } = useAuthContext();
 
   const navigate = useNavigate();
 
@@ -56,7 +56,7 @@ const usePhoneLoginForm = ({
         }),
       )
         .then((otp) => {
-          onSendOTPSuccess(otp as OTP);
+          onSendOTPSuccess(otp as OTPCode);
           navigate(otpPageUrl);
         })
         .catch((err) => {
@@ -69,6 +69,7 @@ const usePhoneLoginForm = ({
     formik,
     isSendOTPLoading,
     sendOTPError,
+    sendOTPResult,
   };
 };
 

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
@@ -6,11 +6,11 @@ import * as Yup from 'yup';
 import constant from '../../../constants';
 import routes from '../../../constants/routes';
 import { useAuthContext } from '../../../contexts';
-import { AsyncError, PhoneNumber } from '../../../types';
+import { AsyncError, OTP, PhoneNumber } from '../../../types';
 
 interface PhoneLoginFormProps {
   onError: (err: AsyncError) => void;
-  onSendOTPSuccess: () => void;
+  onSendOTPSuccess: (otp: OTP) => void;
 }
 
 const usePhoneLoginForm = ({
@@ -55,8 +55,8 @@ const usePhoneLoginForm = ({
           phone_number: formattedPhoneNumber.toString(),
         }),
       )
-        .then(() => {
-          onSendOTPSuccess();
+        .then((otp) => {
+          onSendOTPSuccess(otp as OTP);
           navigate(otpPageUrl);
         })
         .catch((err) => {

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -11,13 +11,13 @@ import {
 } from '../../../components';
 import COUNTRY_SELECT_OPTIONS from '../../../constants/countries';
 import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
+import { AsyncError, OTP } from '../../../types';
 import { ButtonKind, ButtonType } from '../../../types/button';
 
 import usePhoneLoginForm from './phone-login-form.hook';
 
 interface PhoneLoginFormProps {
-  onSendOTPSuccess: () => void;
+  onSendOTPSuccess: (otp: OTP) => void;
   onError: (error: AsyncError) => void;
 }
 

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -11,13 +11,13 @@ import {
 } from '../../../components';
 import COUNTRY_SELECT_OPTIONS from '../../../constants/countries';
 import routes from '../../../constants/routes';
-import { AsyncError, OTP } from '../../../types';
+import { AsyncError, OTPCode } from '../../../types';
 import { ButtonKind, ButtonType } from '../../../types/button';
 
 import usePhoneLoginForm from './phone-login-form.hook';
 
 interface PhoneLoginFormProps {
-  onSendOTPSuccess: (otp: OTP) => void;
+  onSendOTPSuccess: (otp: OTPCode) => void;
   onError: (error: AsyncError) => void;
 }
 

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { AccessToken, ApiResponse, PhoneNumber } from '../types';
+import { AccessToken, ApiResponse, OTP, PhoneNumber } from '../types';
 import { JsonObject } from '../types/common-types';
 
 import APIService from './api.service';
@@ -28,13 +28,15 @@ export default class AuthService extends APIService {
     return new ApiResponse(new AccessToken(response.data));
   };
 
-  sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<void>> =>
-    this.apiClient.post('/accounts', {
+  sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<OTP>> => {
+    const response = await this.apiClient.post<JsonObject>('/accounts', {
       phone_number: {
         country_code: phoneNumber.countryCode,
         phone_number: phoneNumber.phoneNumber,
       },
     });
+    return new ApiResponse(new OTP(response.data));
+  }
 
   verifyOTP = async (
     phoneNumber: PhoneNumber,

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { AccessToken, ApiResponse, OTP, PhoneNumber } from '../types';
+import { AccessToken, ApiResponse, OTPCode, PhoneNumber } from '../types';
 import { JsonObject } from '../types/common-types';
 
 import APIService from './api.service';
@@ -28,14 +28,14 @@ export default class AuthService extends APIService {
     return new ApiResponse(new AccessToken(response.data));
   };
 
-  sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<OTP>> => {
+  sendOTP = async (phoneNumber: PhoneNumber): Promise<ApiResponse<OTPCode>> => {
     const response = await this.apiClient.post<JsonObject>('/accounts', {
       phone_number: {
         country_code: phoneNumber.countryCode,
         phone_number: phoneNumber.phoneNumber,
       },
     });
-    return new ApiResponse(new OTP(response.data));
+    return new ApiResponse(new OTPCode(response.data));
   }
 
   verifyOTP = async (

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -37,3 +37,11 @@ export class PhoneNumber {
     return `${this.countryCode} ${this.phoneNumber}`;
   }
 }
+
+export class OTP {
+  otpCode: string;
+  
+  constructor(json: JsonObject) {
+    this.otpCode = json.otp_code as string;
+  }
+}

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -38,9 +38,9 @@ export class PhoneNumber {
   }
 }
 
-export class OTP {
+export class OTPCode {
   otpCode: string;
-  
+
   constructor(json: JsonObject) {
     this.otpCode = json.otp_code as string;
   }

--- a/src/apps/frontend/types/index.ts
+++ b/src/apps/frontend/types/index.ts
@@ -1,6 +1,6 @@
 import { Account } from './account';
 import { AsyncError, AsyncResult, UseAsyncResponse } from './async-operation';
-import { AccessToken, KeyboardKeys, PhoneNumber, OTP } from './auth';
+import { AccessToken, KeyboardKeys, PhoneNumber, OTPCode } from './auth';
 import { ApiResponse, ApiError } from './service-response';
 
 export {
@@ -13,5 +13,5 @@ export {
   KeyboardKeys,
   PhoneNumber,
   UseAsyncResponse,
-  OTP,
+  OTPCode,
 };

--- a/src/apps/frontend/types/index.ts
+++ b/src/apps/frontend/types/index.ts
@@ -1,6 +1,6 @@
 import { Account } from './account';
 import { AsyncError, AsyncResult, UseAsyncResponse } from './async-operation';
-import { AccessToken, KeyboardKeys, PhoneNumber } from './auth';
+import { AccessToken, KeyboardKeys, PhoneNumber, OTP } from './auth';
 import { ApiResponse, ApiError } from './service-response';
 
 export {
@@ -13,4 +13,5 @@ export {
   KeyboardKeys,
   PhoneNumber,
   UseAsyncResponse,
+  OTP,
 };

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -12,6 +12,7 @@ from modules.account.types import (
 )
 from server import app
 from tests.modules.account.base_test_account import BaseTestAccount
+from modules.config.config_service import ConfigService
 
 
 class TestAccountService(BaseTestAccount):
@@ -68,3 +69,13 @@ class TestAccountService(BaseTestAccount):
         except AccountNotFoundError as exc:
             assert exc.code == AccountErrorCode.NOT_FOUND
             assert exc.message == f"We could not find an account phone number: {phone_number}. Please verify it or you can create a new account."
+
+    def test_get_or_create_account_by_exempt_phone_number(self) -> None:
+        exempted_phone_number = ConfigService.get_otp_config("exempt_phone_number")
+        otp_code = ConfigService.get_otp_config("exempt_otp")
+        phone_number = PhoneNumber(**{"country_code": "+91", "phone_number": exempted_phone_number})
+        account, otp = AccountService.get_or_create_account_by_phone_number(
+            params=CreateAccountByPhoneNumberParams(phone_number=phone_number)
+        )
+        assert otp.otp_code == otp_code
+        assert account.phone_number == PhoneNumber(country_code="+91", phone_number=exempted_phone_number)

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -53,7 +53,7 @@ class TestAccountService(BaseTestAccount):
             assert exc.code == AccountErrorCode.NOT_FOUND
 
     def test_get_or_create_account_by_phone_number(self) -> None:
-        account = AccountService.get_or_create_account_by_phone_number(
+        account, otp = AccountService.get_or_create_account_by_phone_number(
             params=CreateAccountByPhoneNumberParams(
                 phone_number=PhoneNumber(**{"country_code": "+91", "phone_number": "9999999999"})
             )


### PR DESCRIPTION
## Description
_This PR is introduced to resolve #72._

Changes made:

- Refactored existing `default_phone_number` and `otp` to `exempt_phone_number` and `exempt_otp`.
- Introduced a `DEFAULT_OTP_ENABLED` and `DEFAULT_OTP` environment variable which is used to set default_otp which provides a UI hint in non-production scenarios.

UI Hint:
![{57DD8F69-41D7-49EB-9EFB-618DC2C19D93}](https://github.com/user-attachments/assets/6b5a42a0-0afd-4268-8469-6e10e6724553)


## Tests
### Automated test cases added
- _test_get_or_create_account_by_exempt_phone_number_ : Gets the `exempt_phone_number` and `exempt_otp` to check if account is created and response contains the `exempt_phone_number`.

### Manual test cases run
#### User Creation  
- Verified document generation when creating a user using both username/password and phone number/OTP.  

#### Login  
- Verified login functionality using username credentials.  
- Verified login functionality using phone number and OTP. 
- Verified login functionality using `exempt_phone_number` and `exempt_otp`.
- Verified login functionality when `DEFAULT_OTP_ENABLED` is set to true.
- Verified `DEFAULT_OTP_ENABLED` does not return `otp` when in `production`.

#### OTP Errors  
- Invalid OTP: Raised HTTP error 400 (`code`: `OTP_ERR_01`, "invalid otp").  
- Expired OTP: Raised HTTP error 400 (`code`: `OTP_ERR_02`, "expired otp").  

#### Account Errors  
- Incorrect email during login: Raised HTTP error 404 (`code`: `ACCOUNT_ERR_02`, "account not found").  
- Incorrect password during login: Raised HTTP error 403 (`code`: `ACCOUNT_ERR_02`, "invalid password").  
- Incorrect email during password reset: Raised HTTP error 404 (`code`: `ACCOUNT_ERR_02`, "account not found").  
- Existing email during signup: Raised HTTP error 409 (`code`: `ACCOUNT_ERR_01`, "account already exists").  