### PR TITLE
Fix form overextension and enforce max height

### DIFF
--- a/src/apps/frontend/components/layouts/layout-config.tsx
+++ b/src/apps/frontend/components/layouts/layout-config.tsx
@@ -66,7 +66,7 @@ const CenteredFormWithBackgroundLayout: React.FC<{
 const DefaultLayout: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => (
-  <div className="flex items-start justify-center overflow-hidden p-4">
+  <div className="flex h-screen items-start justify-center overflow-hidden p-4">
     <div className="w-full max-w-[550px] p-4">{children}</div>
   </div>
 );

--- a/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
+++ b/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
@@ -10,11 +10,11 @@ interface AuthenticationFormLayoutProps {
 
 const AuthenticationFormLayout: React.FC<AuthenticationFormLayoutProps> = ({
   children,
-  layoutType = LayoutType.Default,
+  layoutType = LayoutType.FullForm,
 }) => (
   <CustomLayout layoutType={layoutType}>
     <div className="flex h-auto min-h-[70vh] items-center justify-center p-4 md:min-h-[50vh] lg:min-h-[60vh]">
-      <div className="w-full rounded-sm border border-stroke bg-white p-4 shadow-default dark:border-strokedark dark:bg-boxdark sm:p-4 md:w-full xl:w-full">
+      <div className="max-h-[85vh] w-full max-w-[550px] rounded-sm border border-stroke bg-white p-4 shadow-default dark:border-strokedark dark:bg-boxdark sm:p-4">
         {children}
       </div>
     </div>


### PR DESCRIPTION

## Description
This PR fixes the issue of the authentication form ensuring the page extends fully to the bottom without scroll ability

## Before (Issue)
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bc41ed33-0090-467e-8217-0419c93310c6" />

- The default layout did not extend fully to the bottom of the page, leading to inconsistent spacing.

## After (Fix)
- The form now has a max-h-[85vh] max-w-[550px] to prevent excessive stretching.
- The default layout now includes h-screen, ensuring it extends fully to the bottom.