### PR TITLE
fix : Fixing datadog logger to send correct log levels

### DIFF
--- a/src/apps/backend/modules/logger/internal/datadog_handler.py
+++ b/src/apps/backend/modules/logger/internal/datadog_handler.py
@@ -14,10 +14,10 @@ class DatadogHandler(StreamHandler):
         StreamHandler.__init__(self)
         self.ddsource = ddsource
 
-    def get_status(self) -> str:
-        if self.level in [logging.NOTSET, logging.DEBUG, logging.INFO]:
+    def __get_status(self, record: LogRecord) -> str:
+        if record.levelno in [logging.NOTSET, logging.DEBUG, logging.INFO]:
             return "info"
-        elif self.level in [logging.WARNING]:
+        elif record.levelno in [logging.WARNING]:
             return "warn"
         else:
             return "error"
@@ -41,7 +41,7 @@ class DatadogHandler(StreamHandler):
                         hostname="",
                         message=msg,
                         service=data_app_name,
-                        status=self.get_status(),
+                        status=self.__get_status(record=record),
                     )
                 ]
             )

--- a/src/apps/backend/modules/logger/internal/datadog_handler.py
+++ b/src/apps/backend/modules/logger/internal/datadog_handler.py
@@ -1,16 +1,26 @@
+import logging
 import os
-from logging import StreamHandler
+from logging import LogRecord, StreamHandler
+
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.v2.api.logs_api import LogsApi
 from datadog_api_client.v2.models import HTTPLog, HTTPLogItem
+
 from modules.config.config_service import ConfigService
-from logging import LogRecord
 
 
 class DatadogHandler(StreamHandler):
     def __init__(self, ddsource: str) -> None:
         StreamHandler.__init__(self)
         self.ddsource = ddsource
+
+    def getStatus(self) -> str:
+        if self.level in [logging.NOTSET, logging.DEBUG, logging.INFO]:
+            return "info"
+        elif self.level in [logging.WARNING]:
+            return "warn"
+        else:
+            return "error"
 
     def emit(self, record: LogRecord) -> None:
         msg = self.format(record)
@@ -31,6 +41,7 @@ class DatadogHandler(StreamHandler):
                         hostname="",
                         message=msg,
                         service=data_app_name,
+                        status=self.getStatus(),
                     )
                 ]
             )

--- a/src/apps/backend/modules/logger/internal/datadog_handler.py
+++ b/src/apps/backend/modules/logger/internal/datadog_handler.py
@@ -14,7 +14,7 @@ class DatadogHandler(StreamHandler):
         StreamHandler.__init__(self)
         self.ddsource = ddsource
 
-    def getStatus(self) -> str:
+    def get_status(self) -> str:
         if self.level in [logging.NOTSET, logging.DEBUG, logging.INFO]:
             return "info"
         elif self.level in [logging.WARNING]:
@@ -41,7 +41,7 @@ class DatadogHandler(StreamHandler):
                         hostname="",
                         message=msg,
                         service=data_app_name,
-                        status=self.getStatus(),
+                        status=self.get_status(),
                     )
                 ]
             )

--- a/src/apps/backend/modules/logger/internal/datadog_logger.py
+++ b/src/apps/backend/modules/logger/internal/datadog_logger.py
@@ -1,4 +1,5 @@
 import logging
+
 from modules.logger.internal.base_logger import BaseLogger
 from modules.logger.internal.datadog_handler import DatadogHandler
 from modules.logger.internal.datadog_handler_level import LogLevel
@@ -9,26 +10,29 @@ class DatadogLogger(BaseLogger):
         self.level = LogLevel.get_level()
         self.logger = logging.getLogger(__name__)
         self.format = "[%(asctime)s] - %(name)s - %(levelname)s - %(message)s"
-        self.formatter = logging.Formatter(
-            self.format,
-        )
+        self.formatter = logging.Formatter(self.format)
         self.logger.setLevel(LogLevel.get_level())
-        self.handler = DatadogHandler('flask')
+        self.handler = DatadogHandler("flask")
         self.handler.setLevel(LogLevel.get_level())
         self.handler.setFormatter(self.formatter)
         self.logger.addHandler(self.handler)
 
     def critical(self, *, message: str) -> None:
+        self.handler.setLevel(logging.CRITICAL)
         self.logger.critical(message)
 
     def debug(self, *, message: str) -> None:
+        self.handler.setLevel(logging.DEBUG)
         self.logger.debug(message)
 
     def error(self, *, message: str) -> None:
+        self.handler.setLevel(logging.ERROR)
         self.logger.error(message)
 
     def info(self, *, message: str) -> None:
+        self.handler.setLevel(logging.INFO)
         self.logger.info(message)
 
     def warn(self, *, message: str) -> None:
+        self.handler.setLevel(logging.WARNING)
         self.logger.warning(message)

--- a/src/apps/backend/modules/logger/internal/datadog_logger.py
+++ b/src/apps/backend/modules/logger/internal/datadog_logger.py
@@ -18,21 +18,16 @@ class DatadogLogger(BaseLogger):
         self.logger.addHandler(self.handler)
 
     def critical(self, *, message: str) -> None:
-        self.handler.setLevel(logging.CRITICAL)
         self.logger.critical(message)
 
     def debug(self, *, message: str) -> None:
-        self.handler.setLevel(logging.DEBUG)
         self.logger.debug(message)
 
     def error(self, *, message: str) -> None:
-        self.handler.setLevel(logging.ERROR)
         self.logger.error(message)
 
     def info(self, *, message: str) -> None:
-        self.handler.setLevel(logging.INFO)
         self.logger.info(message)
 
     def warn(self, *, message: str) -> None:
-        self.handler.setLevel(logging.WARNING)
         self.logger.warning(message)

--- a/src/apps/backend/modules/logger/internal/loggers.py
+++ b/src/apps/backend/modules/logger/internal/loggers.py
@@ -17,7 +17,7 @@ class Loggers:
                 Loggers._LOGGERS.append(Loggers.__get_console_logger())
 
             if logger_transport == LoggerTransports.DATADOG:
-                Loggers._LOGGERS.append(Loggers.__get_datadog_logger())
+                Loggers._loggers.append(Loggers.__get_datadog_logger())
 
     @staticmethod
     def info(*, message: str) -> None:

--- a/src/apps/backend/modules/logger/internal/loggers.py
+++ b/src/apps/backend/modules/logger/internal/loggers.py
@@ -17,7 +17,7 @@ class Loggers:
                 Loggers._LOGGERS.append(Loggers.__get_console_logger())
 
             if logger_transport == LoggerTransports.DATADOG:
-                Loggers._loggers.append(Loggers.__get_datadog_logger())
+                Loggers._Loggers.append(Loggers.__get_datadog_logger())
 
     @staticmethod
     def info(*, message: str) -> None:

--- a/src/apps/backend/modules/logger/internal/loggers.py
+++ b/src/apps/backend/modules/logger/internal/loggers.py
@@ -17,7 +17,7 @@ class Loggers:
                 Loggers._LOGGERS.append(Loggers.__get_console_logger())
 
             if logger_transport == LoggerTransports.DATADOG:
-                Loggers._Loggers.append(Loggers.__get_datadog_logger())
+                Loggers._LOGGERS.append(Loggers.__get_datadog_logger())
 
     @staticmethod
     def info(*, message: str) -> None:


### PR DESCRIPTION
## Description
Enhanced the Datadog logger to ensure that logs are recorded with the correct log level instead of defaulting all logs to `INFO`. This improvement allows better visibility into different log severities in Datadog.

### Manual testing
The changes were tested by temporarily adding log function calls to `server.py` to verify that logs are successfully sent to Datadog with accurate log levels.

###Test Steps : -
- Added Datadog to the logger.transports value in the default environment.
- Configured API keys, application name, and other Datadog-related variables in the environment file.
- Started the Temporal server, then ran npm run serve while injecting errors into a function that:
-- Returns the Flask app.
-- Sends logs before initializing the app.
- Verified that logs were sent to Datadog with the correct severity levels.
[Note that repeated logs occurred due to multithreading behavior, but this was expected and not an issue.]


Screenshots from datadog attached which show correct log level
- Screenshot showcasing INFO logs 
![Screenshot From 2025-03-17 17-36-59](https://github.com/user-attachments/assets/0ce2e3ef-39c0-4154-976a-10a0a207953c)
- Screenshot showcasing ERROR and CRITICAL logs
![Screenshot From 2025-03-17 17-50-25](https://github.com/user-attachments/assets/c28bf39e-f857-4ed5-8904-69e3fa941fdb)


