### PR TITLE
fix: resolve deployment issue due to temporal connection failing

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -6,14 +6,17 @@ mailer:
 mongodb:
   uri: "MONGODB_URI"
 
+temporal:
+  server_address: "TEMPORAL_SERVER_ADDRESS"
+
 web_app_host: "WEB_APP_HOST"
 
 inspectlet:
   key: 'INSPECTLET_KEY'
 
 datadog:
-  api_key: 'DATADOG_API_KEY'   
-  site_name: 'DATADOG_SITE' 
+  api_key: 'DATADOG_API_KEY'
+  site_name: 'DATADOG_SITE'
   app_name: 'DATADOG_APP_NAME'
   log_level: 'DATADOG_LOG_LEVEL'
 

--- a/src/apps/backend/modules/application/errors.py
+++ b/src/apps/backend/modules/application/errors.py
@@ -19,8 +19,8 @@ class WorkerClientConnectionError(AppError):
         super().__init__(
             code=WorkerErrorCode.WORKER_CLIENT_CONNECTION_ERROR,
             http_status_code=500,
-            message=f"Failed to connect to Temporal server. "
-            f"Verify that the temporal server is running at {server_address} and try again.",
+            message=f"System is unable to find a running instance of Temporal server at {server_address}. "
+            f"Please make sure it is running and restart the server.",
         )
 
 


### PR DESCRIPTION
## Description

Currently, the temporal server isn't setup yet for preview and production environments. Therefore, the deployments are failing due to `WorkerClientConnectionError` when we are trying to connect to the Temporal server on app startup.

This is a temporary solution, for the time being we are catching the WorkerClientConnectionError and logging a message, until the temporal setup is complete for preview and production environments. Though once we do finish the setup for temporal, no further changes are required here, simply updating the variable in Doppler.