### PR TITLE
Refactor: Add absolute paths to frontend

### DIFF
--- a/src/apps/frontend/app.component.tsx
+++ b/src/apps/frontend/app.component.tsx
@@ -1,12 +1,11 @@
+import { AccountProvider } from 'frontend/contexts';
+import { AuthProvider } from 'frontend/contexts/auth.provider';
+import { Config } from 'frontend/helpers';
+import { AppRoutes } from 'frontend/routes';
+import InspectLet from 'frontend/vendor/inspectlet';
 import React, { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { BrowserRouter as Router } from 'react-router-dom';
-
-import { AccountProvider } from './contexts';
-import { AuthProvider } from './contexts/auth.provider';
-import { Config } from './helpers';
-import { AppRoutes } from './routes';
-import InspectLet from './vendor/inspectlet';
 
 export default function App(): React.ReactElement {
   useEffect(() => {

--- a/src/apps/frontend/components/button/index.tsx
+++ b/src/apps/frontend/components/button/index.tsx
@@ -1,8 +1,7 @@
 import clsx from 'clsx';
+import Spinner from 'frontend/components/spinner/spinner';
+import { ButtonKind, ButtonType } from 'frontend/types/button';
 import React, { PropsWithChildren } from 'react';
-
-import { ButtonKind, ButtonType } from '../../types/button';
-import Spinner from '../spinner/spinner';
 
 interface ButtonProps {
   disabled?: boolean;

--- a/src/apps/frontend/components/flex/flex-item.component.tsx
+++ b/src/apps/frontend/components/flex/flex-item.component.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
+import styles from 'frontend/components/flex/flex-item.styles';
 import React, { PropsWithChildren } from 'react';
-
-import styles from './flex-item.styles';
 
 interface FlexItemProps {
   alignSelf?: keyof typeof styles.alignSelf;

--- a/src/apps/frontend/components/flex/flex.component.tsx
+++ b/src/apps/frontend/components/flex/flex.component.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
+import styles from 'frontend/components/flex/flex.styles';
 import React, { PropsWithChildren } from 'react';
-
-import styles from './flex.styles';
 
 interface FlexProps {
   alignItems?: keyof typeof styles.alignItems;

--- a/src/apps/frontend/components/form-control/index.tsx
+++ b/src/apps/frontend/components/form-control/index.tsx
@@ -1,6 +1,5 @@
+import VerticalStackLayout from 'frontend/components/layouts/vertical-stack-layout';
 import React, { PropsWithChildren } from 'react';
-
-import VerticalStackLayout from '../layouts/vertical-stack-layout';
 
 interface FormControlProps {
   error?: string;

--- a/src/apps/frontend/components/header/index.tsx
+++ b/src/apps/frontend/components/header/index.tsx
@@ -1,11 +1,9 @@
+import HamburgerToggleButton from 'frontend/components/header/hamburger-toggle-button';
+import UserProfileSnippet from 'frontend/components/header/user-profile-snippet.component';
+import routes from 'frontend/constants/routes';
+import { useAccountContext, useAuthContext } from 'frontend/contexts';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-
-import routes from '../../constants/routes';
-import { useAccountContext, useAuthContext } from '../../contexts';
-
-import HamburgerToggleButton from './hamburger-toggle-button';
-import UserProfileSnippet from './user-profile-snippet.component';
 
 export type UserMenuDropdownItem = {
   iconPath: string;

--- a/src/apps/frontend/components/header/user-menu-dropdown.component.tsx
+++ b/src/apps/frontend/components/header/user-menu-dropdown.component.tsx
@@ -1,6 +1,5 @@
+import { UserMenuDropdownItem } from 'frontend/components/header';
 import React from 'react';
-
-import { UserMenuDropdownItem } from '.';
 
 type UserMenuDropdownProps = {
   dropdownOpen: boolean;

--- a/src/apps/frontend/components/header/user-profile-snippet.component.tsx
+++ b/src/apps/frontend/components/header/user-profile-snippet.component.tsx
@@ -1,12 +1,9 @@
+import { UserMenuDropdownItem } from 'frontend/components/header';
+import UserMenuDropdown from 'frontend/components/header/user-menu-dropdown.component';
+import { Account } from 'frontend/types';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-
-import { Account } from '../../types';
-
-import UserMenuDropdown from './user-menu-dropdown.component';
-
-import { UserMenuDropdownItem } from '.';
 
 interface DropdownUserProps {
   account: Account;

--- a/src/apps/frontend/components/index.ts
+++ b/src/apps/frontend/components/index.ts
@@ -1,16 +1,16 @@
-import Button from './button';
-import FlexItem from './flex/flex-item.component';
-import Flex from './flex/flex.component';
-import FormControl from './form-control';
-import Header from './header';
-import Input from './input';
-import PasswordInput from './input/password-input';
-import HorizontalStackLayout from './layouts/horizontal-stack-layout';
-import VerticalStackLayout from './layouts/vertical-stack-layout';
-import OTP from './otp';
-import Select from './select';
-import H2 from './typography/h2';
-import ParagraphMedium from './typography/paragraph-medium';
+import Button from 'frontend/components/button';
+import FlexItem from 'frontend/components/flex/flex-item.component';
+import Flex from 'frontend/components/flex/flex.component';
+import FormControl from 'frontend/components/form-control';
+import Header from 'frontend/components/header';
+import Input from 'frontend/components/input';
+import PasswordInput from 'frontend/components/input/password-input';
+import HorizontalStackLayout from 'frontend/components/layouts/horizontal-stack-layout';
+import VerticalStackLayout from 'frontend/components/layouts/vertical-stack-layout';
+import OTP from 'frontend/components/otp';
+import Select from 'frontend/components/select';
+import H2 from 'frontend/components/typography/h2';
+import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
 
 export {
   Button,

--- a/src/apps/frontend/components/input/index.tsx
+++ b/src/apps/frontend/components/input/index.tsx
@@ -1,8 +1,7 @@
 import clsx from 'clsx';
+import HorizontalStackLayout from 'frontend/components/layouts/horizontal-stack-layout';
+import { Nullable } from 'frontend/types/common-types';
 import * as React from 'react';
-
-import { Nullable } from '../../types/common-types';
-import HorizontalStackLayout from '../layouts/horizontal-stack-layout';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   endEnhancer?: React.ReactElement | string;

--- a/src/apps/frontend/components/input/password-input.tsx
+++ b/src/apps/frontend/components/input/password-input.tsx
@@ -1,9 +1,7 @@
+import Button from 'frontend/components/button';
+import Input from 'frontend/components/input/';
+import { ButtonKind } from 'frontend/types/button';
 import React, { useState } from 'react';
-
-import { ButtonKind } from '../../types/button';
-import Button from '../button';
-
-import Input from '.';
 
 interface PasswordInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/src/apps/frontend/components/layouts/custom-layout.component.tsx
+++ b/src/apps/frontend/components/layouts/custom-layout.component.tsx
@@ -1,6 +1,5 @@
+import { LayoutConfig, LayoutType } from 'frontend/components/layouts/layout-config';
 import React from 'react';
-
-import { LayoutConfig, LayoutType } from './layout-config';
 
 interface CustomLayoutProps {
   layoutType?: LayoutType;

--- a/src/apps/frontend/components/otp/index.tsx
+++ b/src/apps/frontend/components/otp/index.tsx
@@ -1,9 +1,7 @@
+import OTPInput from 'frontend/components/otp/otp-input';
+import constant from 'frontend/constants';
+import { AsyncError, KeyboardKeys } from 'frontend/types';
 import React, { useRef, useState, FocusEventHandler } from 'react';
-
-import constant from '../../constants';
-import { AsyncError, KeyboardKeys } from '../../types';
-
-import OTPInput from './otp-input';
 
 interface OTPProps {
   error?: string;

--- a/src/apps/frontend/components/otp/otp-input.tsx
+++ b/src/apps/frontend/components/otp/otp-input.tsx
@@ -1,6 +1,5 @@
+import Input from 'frontend/components/input';
 import React, { FocusEventHandler } from 'react';
-
-import Input from '../input';
 
 type OTPInputProps = {
   disabled: boolean;

--- a/src/apps/frontend/components/sidebar/index.tsx
+++ b/src/apps/frontend/components/sidebar/index.tsx
@@ -1,8 +1,6 @@
+import SidebarMenuItem from 'frontend/components/sidebar/sidebar-menu-item';
+import routes from 'frontend/constants/routes';
 import React, { useRef } from 'react';
-
-import routes from '../../constants/routes';
-
-import SidebarMenuItem from './sidebar-menu-item';
 
 type SidebarProps = {
   isSidebarOpen: boolean;

--- a/src/apps/frontend/contexts/account.provider.tsx
+++ b/src/apps/frontend/contexts/account.provider.tsx
@@ -1,16 +1,14 @@
+import useAsync from 'frontend/contexts/async.hook';
+import { AccountService } from 'frontend/services';
+import { Account, ApiResponse, AsyncError } from 'frontend/types';
+import { Nullable } from 'frontend/types/common-types';
+import { getAccessTokenFromStorage } from 'frontend/utils/storage-util';
 import React, {
   createContext,
   PropsWithChildren,
   ReactNode,
   useContext,
 } from 'react';
-
-import { AccountService } from '../services';
-import { Account, ApiResponse, AsyncError } from '../types';
-import { Nullable } from '../types/common-types';
-import { getAccessTokenFromStorage } from '../utils/storage-util';
-
-import useAsync from './async.hook';
 
 type AccountContextType = {
   accountDetails: Account;

--- a/src/apps/frontend/contexts/async.hook.ts
+++ b/src/apps/frontend/contexts/async.hook.ts
@@ -1,8 +1,7 @@
+import { UseAsyncResponse, AsyncResult, AsyncError } from 'frontend/types';
+import { AsyncOperationError } from 'frontend/types/async-operation';
+import { Nullable } from 'frontend/types/common-types';
 import { useCallback, useState } from 'react';
-
-import { UseAsyncResponse, AsyncResult, AsyncError } from '../types';
-import { AsyncOperationError } from '../types/async-operation';
-import { Nullable } from '../types/common-types';
 
 const useAsync = <T>(
   asyncFn: (...args: unknown[]) => Promise<AsyncResult<T>>,

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -1,20 +1,18 @@
+import useAsync from 'frontend/contexts/async.hook';
+import { AuthService } from 'frontend/services';
+import { AccessToken, ApiResponse, AsyncError, PhoneNumber } from 'frontend/types';
+import { Nullable } from 'frontend/types/common-types';
+import {
+  getAccessTokenFromStorage,
+  removeAccessTokenFromStorage,
+  setAccessTokenToStorage,
+} from 'frontend/utils/storage-util';
 import React, {
   createContext,
   PropsWithChildren,
   ReactNode,
   useContext,
 } from 'react';
-
-import { AuthService } from '../services';
-import { AccessToken, ApiResponse, AsyncError, PhoneNumber } from '../types';
-import { Nullable } from '../types/common-types';
-import {
-  getAccessTokenFromStorage,
-  removeAccessTokenFromStorage,
-  setAccessTokenToStorage,
-} from '../utils/storage-util';
-
-import useAsync from './async.hook';
 
 type AuthContextType = {
   isLoginLoading: boolean;

--- a/src/apps/frontend/contexts/index.ts
+++ b/src/apps/frontend/contexts/index.ts
@@ -1,9 +1,9 @@
-import { AccountProvider, useAccountContext } from './account.provider';
-import { AuthProvider, useAuthContext } from './auth.provider';
+import { AccountProvider, useAccountContext } from 'frontend/contexts/account.provider';
+import { AuthProvider, useAuthContext } from 'frontend/contexts/auth.provider';
 import {
   ResetPasswordProvider,
   useResetPasswordContext,
-} from './reset-password.provider';
+} from 'frontend/contexts/reset-password.provider';
 
 export {
   AccountProvider,

--- a/src/apps/frontend/contexts/reset-password.provider.tsx
+++ b/src/apps/frontend/contexts/reset-password.provider.tsx
@@ -1,16 +1,14 @@
+import useAsync from 'frontend/contexts/async.hook';
+import { ResetPasswordParams } from 'frontend/pages/authentication/reset-password/reset-password-form.hook';
+import { ResetPasswordService } from 'frontend/services';
+import { ApiResponse, AsyncError } from 'frontend/types';
+import { Nullable } from 'frontend/types/common-types';
 import React, {
   createContext,
   PropsWithChildren,
   ReactNode,
   useContext,
 } from 'react';
-
-import { ResetPasswordParams } from '../pages/authentication/reset-password/reset-password-form.hook';
-import { ResetPasswordService } from '../services';
-import { ApiResponse, AsyncError } from '../types';
-import { Nullable } from '../types/common-types';
-
-import useAsync from './async.hook';
 
 type ResetPasswordContextType = {
   isResetPasswordLoading: boolean;

--- a/src/apps/frontend/helpers/index.ts
+++ b/src/apps/frontend/helpers/index.ts
@@ -1,1 +1,1 @@
-export * as Config from './config';
+export * as Config from 'frontend/helpers/config';

--- a/src/apps/frontend/index.tsx
+++ b/src/apps/frontend/index.tsx
@@ -1,10 +1,9 @@
+import 'frontend/satoshi.css';
+import 'frontend/style.css';
+
+import App from 'frontend/app.component';
 import React from 'react';
 import ReactDOM from 'react-dom';
-
-import './satoshi.css';
-import './style.css';
-
-import App from './app.component';
 
 document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/src/apps/frontend/pages/app-layout/app-layout.tsx
+++ b/src/apps/frontend/pages/app-layout/app-layout.tsx
@@ -1,7 +1,6 @@
+import { Header } from 'frontend/components';
+import Sidebar from 'frontend/components/sidebar';
 import React, { PropsWithChildren, ReactNode } from 'react';
-
-import { Header } from '../../components';
-import Sidebar from '../../components/sidebar';
 
 export const AppLayout: React.FC<PropsWithChildren<ReactNode>> = ({
   children,

--- a/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
+++ b/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
@@ -1,7 +1,6 @@
+import { CustomLayout } from 'frontend/components/layouts/custom-layout.component';
+import { LayoutType } from 'frontend/components/layouts/layout-config';
 import React from 'react';
-
-import { CustomLayout } from '../../components/layouts/custom-layout.component';
-import { LayoutType } from '../../components/layouts/layout-config';
 
 interface AuthenticationFormLayoutProps {
   children: React.ReactNode;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.hook.ts
@@ -1,9 +1,8 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import { useResetPasswordContext } from 'frontend/contexts';
+import { AsyncError } from 'frontend/types';
 import * as Yup from 'yup';
-
-import constant from '../../../constants';
-import { useResetPasswordContext } from '../../../contexts';
-import { AsyncError } from '../../../types';
 
 interface UseForgotPasswordFormProps {
   onSuccess: (newUsername: string) => void;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.tsx
@@ -1,16 +1,14 @@
-import React from 'react';
-
 import {
   Button,
   FormControl,
   Input,
   VerticalStackLayout,
-} from '../../../components';
-import ParagraphMedium from '../../../components/typography/paragraph-medium';
-import { AsyncError } from '../../../types';
-import { ButtonType } from '../../../types/button';
-
-import useForgotPasswordForm from './forgot-password-form.hook';
+} from 'frontend/components';
+import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
+import useForgotPasswordForm from 'frontend/pages/authentication/forgot-password/forgot-password-form.hook';
+import { AsyncError } from 'frontend/types';
+import { ButtonType } from 'frontend/types/button';
+import React from 'react';
 
 interface ForgotPasswordFormProps {
   onError: (error: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-resend-email.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-resend-email.tsx
@@ -1,10 +1,9 @@
+import { Button, Flex, VerticalStackLayout } from 'frontend/components';
+import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
+import { useResetPasswordContext } from 'frontend/contexts';
+import { AsyncError } from 'frontend/types';
+import { ButtonType } from 'frontend/types/button';
 import React from 'react';
-
-import { Button, Flex, VerticalStackLayout } from '../../../components';
-import ParagraphMedium from '../../../components/typography/paragraph-medium';
-import { useResetPasswordContext } from '../../../contexts';
-import { AsyncError } from '../../../types';
-import { ButtonType } from '../../../types/button';
 
 interface ForgotPasswordResendEmailProps {
   isResendEnabled: boolean;

--- a/src/apps/frontend/pages/authentication/forgot-password/index.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/index.tsx
@@ -1,17 +1,15 @@
+import { Button, H2, VerticalStackLayout } from 'frontend/components';
+import routes from 'frontend/constants/routes';
+import AuthenticationPageLayout from 'frontend/pages/authentication//authentication-page-layout';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import ForgotPasswordForm from 'frontend/pages/authentication/forgot-password/forgot-password-form';
+import ForgotPasswordResendEmail from 'frontend/pages/authentication/forgot-password/forgot-password-resend-email';
+import { AsyncError } from 'frontend/types';
+import { ButtonKind } from 'frontend/types/button';
+import useTimer from 'frontend/utils/use-timer.hook';
 import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-
-import { Button, H2, VerticalStackLayout } from '../../../components';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import { ButtonKind } from '../../../types/button';
-import useTimer from '../../../utils/use-timer.hook';
-import AuthenticationFormLayout from '../authentication-form-layout';
-import AuthenticationPageLayout from '../authentication-page-layout';
-
-import ForgotPasswordForm from './forgot-password-form';
-import ForgotPasswordResendEmail from './forgot-password-resend-email';
 
 export const ForgotPassword: React.FC = () => {
   const passwordResendDelayInSeconds = 60_000;

--- a/src/apps/frontend/pages/authentication/otp/index.tsx
+++ b/src/apps/frontend/pages/authentication/otp/index.tsx
@@ -1,17 +1,15 @@
+import { Button, H2, VerticalStackLayout } from 'frontend/components';
+import constant from 'frontend/constants';
+import routes from 'frontend/constants/routes';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import OTPForm from 'frontend/pages/authentication/otp/otp-form';
+import { AsyncError } from 'frontend/types';
+import { ButtonKind } from 'frontend/types/button';
+import useTimer from 'frontend/utils/use-timer.hook';
 import React from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-
-import { Button, H2, VerticalStackLayout } from '../../../components';
-import constant from '../../../constants';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import { ButtonKind } from '../../../types/button';
-import useTimer from '../../../utils/use-timer.hook';
-import AuthenticationFormLayout from '../authentication-form-layout';
-import AuthenticationPageLayout from '../authentication-page-layout';
-
-import OTPForm from './otp-form';
 
 export const OTPVerificationPage: React.FC = () => {
   const { startTimer, remaininingSecondsStr, isResendEnabled } = useTimer({

--- a/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
+++ b/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
@@ -1,9 +1,8 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import { useAuthContext } from 'frontend/contexts';
+import { AsyncError, PhoneNumber } from 'frontend/types';
 import * as Yup from 'yup';
-
-import constant from '../../../constants';
-import { useAuthContext } from '../../../contexts';
-import { AsyncError, PhoneNumber } from '../../../types';
 
 interface OTPFormProps {
   onError: (error: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/otp/otp-form.tsx
+++ b/src/apps/frontend/pages/authentication/otp/otp-form.tsx
@@ -1,18 +1,16 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-
 import {
   Button,
   Flex,
   FormControl,
   OTP,
   VerticalStackLayout,
-} from '../../../components';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import { ButtonKind, ButtonType } from '../../../types/button';
-
-import useOTPForm from './otp-form-hook';
+} from 'frontend/components';
+import routes from 'frontend/constants/routes';
+import useOTPForm from 'frontend/pages/authentication/otp/otp-form-hook';
+import { AsyncError } from 'frontend/types';
+import { ButtonKind, ButtonType } from 'frontend/types/button';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface OTPFormProps {
   isResendEnabled: boolean;

--- a/src/apps/frontend/pages/authentication/phone-login/index.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/index.tsx
@@ -1,12 +1,10 @@
+import { H2, VerticalStackLayout } from 'frontend/components';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import PhoneLoginForm from 'frontend/pages/authentication/phone-login/phone-login-form';
+import { AsyncError } from 'frontend/types';
 import React from 'react';
 import toast from 'react-hot-toast';
-
-import { H2, VerticalStackLayout } from '../../../components';
-import { AsyncError } from '../../../types';
-import AuthenticationFormLayout from '../authentication-form-layout';
-import AuthenticationPageLayout from '../authentication-page-layout';
-
-import PhoneLoginForm from './phone-login-form';
 
 export const PhoneLogin: React.FC = () => {
   const onSendOTPSuccess = () => {

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
@@ -1,12 +1,11 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import routes from 'frontend/constants/routes';
+import { useAuthContext } from 'frontend/contexts';
+import { AsyncError, PhoneNumber } from 'frontend/types';
 import { PhoneNumberUtil } from 'google-libphonenumber';
 import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
-
-import constant from '../../../constants';
-import routes from '../../../constants/routes';
-import { useAuthContext } from '../../../contexts';
-import { AsyncError, PhoneNumber } from '../../../types';
 
 interface PhoneLoginFormProps {
   onError: (err: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   Button,
   Flex,
@@ -7,12 +5,12 @@ import {
   Input,
   Select,
   VerticalStackLayout,
-} from '../../../components';
-import COUNTRY_SELECT_OPTIONS from '../../../constants/countries';
-import { AsyncError } from '../../../types';
-import { ButtonKind, ButtonType } from '../../../types/button';
-
-import usePhoneLoginForm from './phone-login-form.hook';
+} from 'frontend/components';
+import COUNTRY_SELECT_OPTIONS from 'frontend/constants/countries';
+import usePhoneLoginForm from 'frontend/pages/authentication/phone-login/phone-login-form.hook';
+import { AsyncError } from 'frontend/types';
+import { ButtonKind, ButtonType } from 'frontend/types/button';
+import React from 'react';
 
 interface PhoneLoginFormProps {
   onSendOTPSuccess: () => void;

--- a/src/apps/frontend/pages/authentication/reset-password/index.tsx
+++ b/src/apps/frontend/pages/authentication/reset-password/index.tsx
@@ -1,15 +1,13 @@
+import { H2, VerticalStackLayout } from 'frontend/components';
+import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
+import routes from 'frontend/constants/routes';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import ResetPasswordForm from 'frontend/pages/authentication/reset-password/reset-password-form';
+import { AsyncError } from 'frontend/types';
 import React from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-
-import { H2, VerticalStackLayout } from '../../../components';
-import ParagraphMedium from '../../../components/typography/paragraph-medium';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import AuthenticationFormLayout from '../authentication-form-layout';
-import AuthenticationPageLayout from '../authentication-page-layout';
-
-import ResetPasswordForm from './reset-password-form';
 
 export const ResetPassword: React.FC = () => {
   const navigate = useNavigate();

--- a/src/apps/frontend/pages/authentication/reset-password/reset-password-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/reset-password/reset-password-form.hook.ts
@@ -1,10 +1,9 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import { useResetPasswordContext } from 'frontend/contexts';
+import { AsyncError } from 'frontend/types';
 import { useLocation, useParams } from 'react-router-dom';
 import * as Yup from 'yup';
-
-import constant from '../../../constants';
-import { useResetPasswordContext } from '../../../contexts';
-import { AsyncError } from '../../../types';
 
 export type ResetPasswordParams = {
   accountId: string;

--- a/src/apps/frontend/pages/authentication/reset-password/reset-password-form.tsx
+++ b/src/apps/frontend/pages/authentication/reset-password/reset-password-form.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
-
 import {
   Button,
   FormControl,
   PasswordInput,
   VerticalStackLayout,
-} from '../../../components';
-import { AsyncError } from '../../../types';
-import { ButtonType } from '../../../types/button';
-
-import useResetPasswordForm from './reset-password-form.hook';
+} from 'frontend/components';
+import useResetPasswordForm from 'frontend/pages/authentication/reset-password/reset-password-form.hook';
+import { AsyncError } from 'frontend/types';
+import { ButtonType } from 'frontend/types/button';
+import React from 'react';
 
 interface ResetPasswordFormProps {
   onSuccess: () => void;

--- a/src/apps/frontend/pages/authentication/signup/index.tsx
+++ b/src/apps/frontend/pages/authentication/signup/index.tsx
@@ -1,14 +1,12 @@
+import { H2, VerticalStackLayout } from 'frontend/components';
+import routes from 'frontend/constants/routes';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import SignupForm from 'frontend/pages/authentication/signup/signup-form';
+import { AsyncError } from 'frontend/types';
 import React from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-
-import { H2, VerticalStackLayout } from '../../../components';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import AuthenticationFormLayout from '../authentication-form-layout';
-import AuthenticationPageLayout from '../authentication-page-layout';
-
-import SignupForm from './signup-form';
 
 export const Signup: React.FC = () => {
   const navigate = useNavigate();

--- a/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
@@ -1,9 +1,8 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import { useAuthContext } from 'frontend/contexts';
+import { AsyncError } from 'frontend/types';
 import * as Yup from 'yup';
-
-import constant from '../../../constants';
-import { useAuthContext } from '../../../contexts';
-import { AsyncError } from '../../../types';
 
 interface SignupFormProps {
   onError: (err: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/signup/signup-form.tsx
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-
 import {
   Button,
   Flex,
@@ -8,14 +5,15 @@ import {
   Input,
   PasswordInput,
   VerticalStackLayout,
-} from '../../../components';
-import { CustomLayout } from '../../../components/layouts/custom-layout.component';
-import { LayoutType } from '../../../components/layouts/layout-config';
-import routes from '../../../constants/routes';
-import { AsyncError } from '../../../types';
-import { ButtonKind, ButtonType } from '../../../types/button';
-
-import useSignupForm from './signup-form.hook';
+} from 'frontend/components';
+import { CustomLayout } from 'frontend/components/layouts/custom-layout.component';
+import { LayoutType } from 'frontend/components/layouts/layout-config';
+import routes from 'frontend/constants/routes';
+import useSignupForm from 'frontend/pages/authentication/signup/signup-form.hook';
+import { AsyncError } from 'frontend/types';
+import { ButtonKind, ButtonType } from 'frontend/types/button';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 type SignupFields =
   | 'firstName'

--- a/src/apps/frontend/pages/index.ts
+++ b/src/apps/frontend/pages/index.ts
@@ -1,12 +1,12 @@
-import About from './about/about.page';
-import ForgotPassword from './authentication/forgot-password';
-import OTPVerificationPage from './authentication/otp';
-import PhoneLogin from './authentication/phone-login';
-import ResetPassword from './authentication/reset-password';
-import Signup from './authentication/signup';
-import Dashboard from './dashboard';
-import Login from './login';
-import NotFound from './not-found/not-found.page';
+import About from 'frontend/pages/about/about.page';
+import ForgotPassword from 'frontend/pages/authentication/forgot-password';
+import OTPVerificationPage from 'frontend/pages/authentication/otp';
+import PhoneLogin from 'frontend/pages/authentication/phone-login';
+import ResetPassword from 'frontend/pages/authentication/reset-password';
+import Signup from 'frontend/pages/authentication/signup';
+import Dashboard from 'frontend/pages/dashboard';
+import Login from 'frontend/pages/login';
+import NotFound from 'frontend/pages/not-found/not-found.page';
 
 export {
   About,

--- a/src/apps/frontend/pages/login/index.tsx
+++ b/src/apps/frontend/pages/login/index.tsx
@@ -1,12 +1,11 @@
+import { VerticalStackLayout, H2 } from 'frontend/components';
+import routes from 'frontend/constants/routes';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import { AsyncError } from 'frontend/types';
 import React from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-
-import { VerticalStackLayout, H2 } from '../../components';
-import routes from '../../constants/routes';
-import { AsyncError } from '../../types';
-import AuthenticationFormLayout from '../authentication/authentication-form-layout';
-import AuthenticationPageLayout from '../authentication/authentication-page-layout';
 
 import LoginForm from './login-form';
 

--- a/src/apps/frontend/pages/login/login-form.hook.ts
+++ b/src/apps/frontend/pages/login/login-form.hook.ts
@@ -1,9 +1,8 @@
 import { useFormik } from 'formik';
+import constant from 'frontend/constants';
+import { useAuthContext } from 'frontend/contexts';
+import { AsyncError } from 'frontend/types';
 import * as Yup from 'yup';
-
-import constant from '../../constants';
-import { useAuthContext } from '../../contexts';
-import { AsyncError } from '../../types';
 
 interface LoginFormProps {
   onSuccess: () => void;

--- a/src/apps/frontend/pages/login/login-form.tsx
+++ b/src/apps/frontend/pages/login/login-form.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-
+import { AsyncError } from 'frontend//types';
 import {
   VerticalStackLayout,
   FormControl,
@@ -8,15 +6,15 @@ import {
   Flex,
   Button,
   Input,
-} from '../../components';
-import { CustomLayout } from '../../components/layouts/custom-layout.component';
-import { LayoutType } from '../../components/layouts/layout-config';
-import routes from '../../constants/routes';
-import { AsyncError } from '../../types';
-import { ButtonType, ButtonKind } from '../../types/button';
-
-import LoginFormCheckbox from './login-form-checkbox';
-import useLoginForm from './login-form.hook';
+} from 'frontend/components';
+import { CustomLayout } from 'frontend/components/layouts/custom-layout.component';
+import { LayoutType } from 'frontend/components/layouts/layout-config';
+import routes from 'frontend/constants/routes';
+import LoginFormCheckbox from 'frontend/pages/login/login-form-checkbox';
+import useLoginForm from 'frontend/pages/login/login-form.hook';
+import { ButtonType, ButtonKind } from 'frontend/types/button';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 type LoginFields = 'username' | 'password';
 

--- a/src/apps/frontend/routes/index.tsx
+++ b/src/apps/frontend/routes/index.tsx
@@ -1,10 +1,8 @@
+import { useAuthContext } from 'frontend/contexts';
+import { protectedRoutes } from 'frontend/routes/protected';
+import { publicRoutes } from 'frontend/routes/public';
 import React from 'react';
 import { useRoutes } from 'react-router-dom';
-
-import { useAuthContext } from '../contexts';
-
-import { protectedRoutes } from './protected';
-import { publicRoutes } from './public';
 
 export const AppRoutes = () => {
   const { isUserAuthenticated } = useAuthContext();

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -1,12 +1,11 @@
+import routes from 'frontend/constants/routes';
+import { useAccountContext, useAuthContext } from 'frontend/contexts';
+import { Dashboard, NotFound } from 'frontend/pages';
+import AppLayout from 'frontend/pages/app-layout/app-layout';
+import { AsyncError } from 'frontend/types';
 import React, { useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { Outlet, useNavigate } from 'react-router-dom';
-
-import routes from '../constants/routes';
-import { useAccountContext, useAuthContext } from '../contexts';
-import { Dashboard, NotFound } from '../pages';
-import AppLayout from '../pages/app-layout/app-layout';
-import { AsyncError } from '../types';
 
 const App = () => {
   const { getAccountDetails } = useAccountContext();

--- a/src/apps/frontend/routes/public.tsx
+++ b/src/apps/frontend/routes/public.tsx
@@ -1,10 +1,7 @@
-import React from 'react';
-import { Navigate } from 'react-router-dom';
-
-import constant from '../constants';
-import routes from '../constants/routes';
-import { ResetPasswordProvider } from '../contexts';
-import { Config } from '../helpers';
+import constant from 'frontend/constants';
+import routes from 'frontend/constants/routes';
+import { ResetPasswordProvider } from 'frontend/contexts';
+import { Config } from 'frontend/helpers';
 import {
   About,
   ForgotPassword,
@@ -13,7 +10,9 @@ import {
   PhoneLogin,
   ResetPassword,
   Signup,
-} from '../pages';
+} from 'frontend/pages';
+import React from 'react';
+import { Navigate } from 'react-router-dom';
 
 const currentAuthMechanism = Config.getConfigValue<string>(
   'authenticationMechanism',

--- a/src/apps/frontend/services/account.service.ts
+++ b/src/apps/frontend/services/account.service.ts
@@ -1,6 +1,5 @@
-import { Account, AccessToken, ApiResponse } from '../types';
-
-import APIService from './api.service';
+import APIService from 'frontend/services/api.service';
+import { Account, AccessToken, ApiResponse } from 'frontend/types';
 
 export default class AccountService extends APIService {
   getAccountDetails = async (

--- a/src/apps/frontend/services/api.service.ts
+++ b/src/apps/frontend/services/api.service.ts
@@ -1,6 +1,5 @@
 import { AxiosInstance } from 'axios';
-
-import AppService from './app.service';
+import AppService from 'frontend/services/app.service';
 
 export default class APIService extends AppService {
   apiClient: AxiosInstance;

--- a/src/apps/frontend/services/auth.service.ts
+++ b/src/apps/frontend/services/auth.service.ts
@@ -1,7 +1,6 @@
-import { AccessToken, ApiResponse, PhoneNumber } from '../types';
-import { JsonObject } from '../types/common-types';
-
-import APIService from './api.service';
+import APIService from 'frontend/services/api.service';
+import { AccessToken, ApiResponse, PhoneNumber } from 'frontend/types';
+import { JsonObject } from 'frontend/types/common-types';
 
 export default class AuthService extends APIService {
   signup = async (

--- a/src/apps/frontend/services/index.ts
+++ b/src/apps/frontend/services/index.ts
@@ -1,6 +1,6 @@
-import AccountService from './account.service';
-import APIService from './api.service';
-import AuthService from './auth.service';
-import ResetPasswordService from './reset-password.service';
+import AccountService from 'frontend/services/account.service';
+import APIService from 'frontend/services/api.service';
+import AuthService from 'frontend/services/auth.service';
+import ResetPasswordService from 'frontend/services/reset-password.service';
 
 export { AccountService, APIService, AuthService, ResetPasswordService };

--- a/src/apps/frontend/services/reset-password.service.ts
+++ b/src/apps/frontend/services/reset-password.service.ts
@@ -1,7 +1,6 @@
-import { ResetPasswordParams } from '../pages/authentication/reset-password/reset-password-form.hook';
-import { ApiResponse } from '../types';
-
-import APIService from './api.service';
+import { ResetPasswordParams } from 'frontend/pages/authentication/reset-password/reset-password-form.hook';
+import APIService from 'frontend/services/api.service';
+import { ApiResponse } from 'frontend/types';
 
 export default class ResetPasswordService extends APIService {
   sendForgotPasswordEmail = async (

--- a/src/apps/frontend/types/account.ts
+++ b/src/apps/frontend/types/account.ts
@@ -1,5 +1,5 @@
-import { PhoneNumber } from './auth';
-import { JsonObject, Nullable } from './common-types';
+import { PhoneNumber } from 'frontend/types/auth';
+import { JsonObject, Nullable } from 'frontend/types/common-types';
 
 export class Account {
   id: string;

--- a/src/apps/frontend/types/async-operation.ts
+++ b/src/apps/frontend/types/async-operation.ts
@@ -1,4 +1,4 @@
-import { JsonObject, Nullable } from './common-types';
+import { JsonObject, Nullable } from 'frontend/types/common-types';
 
 export interface AsyncError {
   code: string;

--- a/src/apps/frontend/types/auth.ts
+++ b/src/apps/frontend/types/auth.ts
@@ -1,4 +1,4 @@
-import { JsonObject } from './common-types';
+import { JsonObject } from 'frontend/types/common-types';
 
 export class AccessToken {
   accountId: string;

--- a/src/apps/frontend/types/index.ts
+++ b/src/apps/frontend/types/index.ts
@@ -1,7 +1,7 @@
-import { Account } from './account';
-import { AsyncError, AsyncResult, UseAsyncResponse } from './async-operation';
-import { AccessToken, KeyboardKeys, PhoneNumber } from './auth';
-import { ApiResponse, ApiError } from './service-response';
+import { Account } from 'frontend/types/account';
+import { AsyncError, AsyncResult, UseAsyncResponse } from 'frontend/types/async-operation';
+import { AccessToken, KeyboardKeys, PhoneNumber } from 'frontend/types/auth';
+import { ApiResponse, ApiError } from 'frontend/types/service-response';
 
 export {
   AccessToken,

--- a/src/apps/frontend/types/service-response.ts
+++ b/src/apps/frontend/types/service-response.ts
@@ -1,5 +1,5 @@
-import { AsyncError, AsyncResult } from './async-operation';
-import { JsonObject } from './common-types';
+import { AsyncError, AsyncResult } from 'frontend/types/async-operation';
+import { JsonObject } from 'frontend/types/common-types';
 
 export class ApiError implements AsyncError {
   code: string;

--- a/src/apps/frontend/utils/storage-util.ts
+++ b/src/apps/frontend/utils/storage-util.ts
@@ -1,5 +1,5 @@
-import { AccessToken } from '../types';
-import { JsonObject, Nullable } from '../types/common-types';
+import { AccessToken } from 'frontend/types';
+import { JsonObject, Nullable } from 'frontend/types/common-types';
 
 const ACCESS_TOKEN_KEY = 'access-token';
 

--- a/src/apps/frontend/webpack.base.js
+++ b/src/apps/frontend/webpack.base.js
@@ -69,5 +69,8 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      frontend: path.resolve(__dirname),
+    },
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,10 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "frontend/*": ["src/apps/frontend/*"],
+    }
   }
 }


### PR DESCRIPTION
## **Description**  
This PR refactors all relative imports in the frontend to use absolute paths, improving code readability and maintainability.  

### **Why this change is needed**  
As the frontend codebase grows with an increasing number of nested folders, relative imports (`../../../`) become harder to read and maintain. Using absolute paths enhances code clarity, making it easier to navigate and modify without unnecessary refactoring.  

## **Database Schema Changes**  
_N/A_  

## **Tests**  
### **Automated Tests Added**  
- _N/A_  

### **Manual Tests Conducted**  
The following manual tests were performed to ensure the application works as expected after updating import paths:  
1. Verified the application builds successfully with the new alias-based imports.  
2. Checked key UI components to ensure they render correctly without import errors.  
3. Tested navigation and dynamic imports to confirm paths are resolved properly.  