### PR TITLE
refactor: change the worker architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ class ExampleWorker(BaseWorker):
         await super().run(*args)
 ```
 
+Optionally, you can specify the following parameters in the worker class:
+
+1. `max_execution_time_in_seconds` - The time in seconds to wait for the worker to finish its execution. If the worker does not finish within this time, it will be cancelled.
+2. `max_reties` - The maximum number of times the worker will be retried in case of failure. If the worker fails more than this number of times, it will be marked as failed and will not be retried again.
+
 Once a worker is defined, it needs to be imported in the [`temporal_config.py`](src/apps/backend/temporal_config.py) and added to the `WORKERS` list.
 
 Hereafter, the system will take care of registering the worker with the Temporal server.

--- a/src/apps/backend/modules/application/application_service.py
+++ b/src/apps/backend/modules/application/application_service.py
@@ -14,12 +14,16 @@ class ApplicationService:
         return WorkerManager.get_worker_by_id(worker_id=worker_id)
 
     @staticmethod
-    def run_worker_immediately(*, cls: Type[BaseWorker], arguments: Tuple[Any, ...] = ()) -> str:
+    def run_worker_immediately(
+        *, cls: Type[BaseWorker], arguments: Tuple[Any, ...] = ()
+    ) -> str:
         return WorkerManager.run_worker_immediately(cls=cls, arguments=arguments)
 
     @staticmethod
-    def schedule_worker_as_cron(*, cls: Type[BaseWorker], arguments: Tuple[Any, ...] = (), cron_schedule: str) -> str:
-        return WorkerManager.schedule_worker_as_cron(cls=cls, arguments=arguments, cron_schedule=cron_schedule)
+    def schedule_worker_as_cron(*, cls: Type[BaseWorker], cron_schedule: str) -> str:
+        return WorkerManager.schedule_worker_as_cron(
+            cls=cls, cron_schedule=cron_schedule
+        )
 
     @staticmethod
     def cancel_worker(*, worker_id: str) -> None:

--- a/src/apps/backend/modules/application/types.py
+++ b/src/apps/backend/modules/application/types.py
@@ -20,6 +20,8 @@ class BaseWorker(ABC):
     """
 
     priority: WorkerPriority = WorkerPriority.DEFAULT
+    max_execution_time_in_seconds: int = 600
+    max_retries: int = 3
 
     @staticmethod
     @abstractmethod
@@ -36,8 +38,10 @@ class BaseWorker(ABC):
         await workflow.execute_activity(
             self.execute,
             args=args,
-            start_to_close_timeout=timedelta(seconds=600),
-            retry_policy=RetryPolicy(maximum_attempts=5),
+            start_to_close_timeout=timedelta(
+                seconds=self.max_execution_time_in_seconds
+            ),
+            retry_policy=RetryPolicy(maximum_attempts=self.max_retries),
         )
 
 

--- a/src/apps/backend/modules/application/workers/health_check_worker.py
+++ b/src/apps/backend/modules/application/workers/health_check_worker.py
@@ -7,10 +7,13 @@ from modules.logger.logger import Logger
 
 
 class HealthCheckWorker(BaseWorker):
+    max_execution_time_in_seconds = 10
+    max_retries = 1
+
     @staticmethod
     async def execute(*args: Any) -> None:
         try:
-            res = requests.get("http://localhost:8080/api/")
+            res = requests.get("http://localhost:8080/api/", timeout=3)
 
             if res.status_code == 200:
                 Logger.info(message="Backend is healthy")

--- a/tests/modules/application/test_application_service.py
+++ b/tests/modules/application/test_application_service.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from pytest import MonkeyPatch
 from temporalio.client import WorkflowExecutionStatus
 from tests.modules.application.base_test_application import BaseTestApplication
 
@@ -8,9 +9,10 @@ from modules.application.application_service import ApplicationService
 from modules.application.errors import WorkerIdNotFoundError, WorkerNotRegisteredError
 from modules.application.types import BaseWorker
 from modules.application.workers.health_check_worker import HealthCheckWorker
+from modules.logger.logger import Logger
 
 
-class TestWorkerService(BaseTestApplication):
+class TestApplicationService(BaseTestApplication):
     def test_run_worker_immediately(self) -> None:
         worker_id = ApplicationService.run_worker_immediately(cls=HealthCheckWorker)
         assert worker_id
@@ -49,3 +51,42 @@ class TestWorkerService(BaseTestApplication):
     def test_get_details_with_invalid_worker_id(self) -> None:
         with pytest.raises(WorkerIdNotFoundError):
             ApplicationService.get_worker_by_id(worker_id="invalid_id")
+
+    def test_duplicate_cron_not_scheduled(self) -> None:
+        monkeypatch = MonkeyPatch()
+
+        log_messages = []
+
+        def fake_info(message: str) -> None:
+            log_messages.append(message)
+
+        monkeypatch.setattr(Logger, "info", fake_info)
+
+        cron_schedule = "*/1 * * * *"
+        worker_id_first = ApplicationService.schedule_worker_as_cron(
+            cls=HealthCheckWorker, cron_schedule=cron_schedule
+        )
+        assert worker_id_first
+
+        worker_details = ApplicationService.get_worker_by_id(worker_id=worker_id_first)
+        assert worker_details.id == worker_id_first
+        assert worker_details.status == WorkflowExecutionStatus.RUNNING
+
+        worker_id_duplicate = ApplicationService.schedule_worker_as_cron(
+            cls=HealthCheckWorker, cron_schedule=cron_schedule
+        )
+        assert worker_id_first == worker_id_duplicate
+
+        duplicate_log = (
+            f"Worker {worker_id_first} already running, skipping starting new instance"
+        )
+        assert any(
+            duplicate_log in log for log in log_messages
+        ), "Expected duplicate log message not found"
+
+        ApplicationService.terminate_worker(worker_id=worker_id_first)
+        time.sleep(1)
+        terminated_worker_details = ApplicationService.get_worker_by_id(
+            worker_id=worker_id_first
+        )
+        assert terminated_worker_details.status == WorkflowExecutionStatus.TERMINATED


### PR DESCRIPTION
## Description

There are three changes in this PR directed towards the worker architecture:
1. `WorkerManager` refactored to use `_get_client` instead of directly calling the `CLIENT` attribute, because it may not be defined in case the connection the Temporal server failed, and if any service method calls when the connection failed, an AttributeNotFoundError is raised instead of a graceful error message, which leads to internal server error and deteriorates UX. 
2. Cron workers have been restructured to only be scheduled if the same cron isn't already running, instead logging a graceful message that the worker is already running. This fixes both the multithreading problem and the issue with rescheduling a cron worker on application restart. 
3. `start_to_close_timeout_in_seconds` and `maximum_retry_attempts` have been made configurable for each worker as these may vary depending on the workload in that worker. The default values for these are set at 10 minutes for timeout and 3 retry attempts. 

## Database schema changes
N/A

## Tests
### Automated test cases added
Renamed `TestWorkerService` to `TestApplicationService`, as it was a typo earlier

`TestApplicationService`
- +`test_duplicate_cron_not_scheduled`

### Manual test cases run
 Logs from app startup, indicating only one cron was scheduled and the others were gracefully skipped:
```
2025-04-09 13:01:44,405 - modules.logger.internal.console_logger - INFO - Worker HealthCheckWorker-cron already running, skipping starting new instance.
2025-04-09 13:01:44,407 - modules.logger.internal.console_logger - INFO - Worker HealthCheckWorker-cron already running, skipping starting new instance.
```

A screenshot from Temporal UI confirming the same:
<img width="1625" alt="image" src="https://github.com/user-attachments/assets/c1d5dd0b-08f7-4b21-81de-7e9e4bd23a98" />
