### PR TITLE
fix: modify Temporal deployment logic to prevent reuse across PRs

### DIFF
--- a/lib/kube/preview/temporal-deployment.yaml
+++ b/lib/kube/preview/temporal-deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: temporal-deployment
+  name: $KUBE_APP-temporal-deployment
   namespace: $KUBE_NS
   labels:
-    app: temporal
-    version: $GITHUB_SHA
+    app: $KUBE_APP-temporal
+  version: $GITHUB_SHA
   annotations:
     secrets.doppler.com/reload: 'true'
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: temporal
+      app: $KUBE_APP-temporal
   template:
     metadata:
       labels:
-        app: temporal
+        app: $KUBE_APP-temporal
     spec:
       imagePullSecrets:
         - name: regcred

--- a/lib/kube/preview/temporal-deployment.yaml
+++ b/lib/kube/preview/temporal-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: $KUBE_NS
   labels:
     app: $KUBE_APP-temporal
-  version: $GITHUB_SHA
+    version: $GITHUB_SHA
   annotations:
     secrets.doppler.com/reload: 'true'
 spec:

--- a/lib/kube/shared/ingress.yaml
+++ b/lib/kube/shared/ingress.yaml
@@ -33,6 +33,6 @@ spec:
             path: "/"
             backend:
               service:
-                name: temporal
+                name: $KUBE_APP-temporal
                 port:
                   number: 8080

--- a/lib/kube/shared/service.yaml
+++ b/lib/kube/shared/service.yaml
@@ -17,10 +17,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: temporal-grpc
+  name: $KUBE_APP-temporal-grpc
   namespace: $KUBE_NS
   labels:
-    app: temporal
+    app: $KUBE_APP-temporal
 spec:
   type: ClusterIP
   ports:
@@ -28,16 +28,16 @@ spec:
       port: 7233
       targetPort: 7233
   selector:
-    app: temporal
+    app: $KUBE_APP-temporal
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: temporal
+  name: $KUBE_APP-temporal
   namespace: $KUBE_NS
   labels:
-    app: temporal
+    app: $KUBE_APP-temporal
 spec:
   type: ClusterIP
   ports:
@@ -45,4 +45,4 @@ spec:
       port: 8080
       targetPort: 8080
   selector:
-    app: temporal
+    app: $KUBE_APP-temporal


### PR DESCRIPTION
## Description
_This PR address the issue where the temporal-deployment for multiple PRs referring to single deployment_

## Database schema changes
_NA._

