### PR TITLE
fix: indentation syntax error at temporal-deployment.yaml

### DIFF
--- a/lib/kube/production/temporal-deployment.yaml
+++ b/lib/kube/production/temporal-deployment.yaml
@@ -27,9 +27,8 @@ spec:
                     operator: In
                     values:
                       - platform-cluster-01-production-pool
-        imagePullSecrets:
-          - name: regcred
-
+      imagePullSecrets:
+        - name: regcred
       containers:
         - name: temporal-server
           image: temporalio/auto-setup:1.22.4


### PR DESCRIPTION
## Description
_This PR resolves issue for indentation error at `production/temporal-deployment.yaml`._

## Database schema changes
_NA._
