### PR TITLE
feat: add probes to temporal containers

### DIFF
--- a/lib/kube/preview/temporal-deployment.yaml
+++ b/lib/kube/preview/temporal-deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     secrets.doppler.com/reload: 'true'
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: $KUBE_APP-temporal
@@ -51,6 +56,19 @@ spec:
               memory: '200Mi'
             limits:
               memory: '400Mi'
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 7233
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 7233
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 5
 
         - name: temporal-admin-tools
           image: temporalio/admin-tools:1.22.4
@@ -84,6 +102,19 @@ spec:
               memory: '200Mi'
             limits:
               memory: '400Mi'
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 5
 
         - name: python-worker
           image: $KUBE_DEPLOYMENT_IMAGE

--- a/lib/kube/production/temporal-deployment.yaml
+++ b/lib/kube/production/temporal-deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     secrets.doppler.com/reload: 'true'
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: $KUBE_APP-temporal
@@ -50,6 +55,19 @@ spec:
               memory: '200Mi'
             limits:
               memory: '400Mi'
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 7233
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 7233
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 5
 
         - name: temporal-admin-tools
           image: temporalio/admin-tools:1.22.4
@@ -83,6 +101,19 @@ spec:
               memory: '200Mi'
             limits:
               memory: '400Mi'
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 5
 
         - name: python-worker
           image: $KUBE_DEPLOYMENT_IMAGE


### PR DESCRIPTION
## Description  
This pull request updates the `temporal-deployment.yaml` to improve pod lifecycle control and resource stability.
  
- Ensure **only one pod** is ever scheduled when `replicas: 1`, even during updates.  
- Add `startup and readiness probes` to applicable containers to prevent restarts or traffic routing to unready pods.

These changes help prevent node memory exhaustion and stuck deployments caused by duplicate pod creation.

## Database schema changes  
_NA_
