### PR TITLE
feat: Add github badge for build and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Boilerplate project for Flask, React & MongoDB based projects. This README documents the steps necessary to get your
 application up and running.
 
+## Badge Reports
+
+| Build Status | Code Coverage |
+| ------------ | ------------- |
+| [![Production Deploy](https://github.com/jalantechnologies/rflask-boilerplate/actions/workflows/production_on_push.yml/badge.svg?branch=main)](https://github.com/jalantechnologies/rflask-boilerplate/actions/workflows/production_on_push.yml) | [![Code Coverage](https://sonarqube.platform.jalantechnologies.com/api/project_badges/measure?project=jalantechnologies_rflask-boilerplate&metric=coverage&token=a4dd71c68afbb8da4b7ed1026329bf0933298f79)](https://sonarqube.platform.jalantechnologies.com/dashboard?id=jalantechnologies_rflask-boilerplate) |
+
 ## Table of Contents
 
 - [Boilerplate - FRM](#boilerplate---frm)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Steps:
 - Create a python file under - `src/apps/backend/scripts` (ex - `my-script.py`)
 - Run the script using npm - `npm run script --file=example_worker_script`
 
+## Github Badges Configuration
+This project displays GitHub badges for SonarQube code coverage and the `production_on_push` workflow status, both referencing the `main` branch of the [`rflask-boilerplate`](https://github.com/jalantechnologies/rflask-boilerplate) repository. If you fork or host this project in a different GitHub repository, update the badge URLs to point to your repository to ensure accurate status and coverage reporting.
+
 ## Workers
 
 This application supports queuing workers from the web application which are run independent of the web server by [Temporal](https://temporal.io/).


### PR DESCRIPTION
## Description
_Adds a badge for code coverage and `production_on_push` for main branch._

 ⚠️ **Note:**  
 It is not possible to refer to dynamic branch names or repository names in GitHub README files for badges.
 
 Currently, we are displaying:
 - **Code Coverage**
 - **Production Deploy Status**
 
 The **Production Deploy** badge reflects the status of the `production_on_push` workflow, which includes:
 - Running tests
 - Building the application
 - Deploying to production
 
 Since we have a **single workflow** at the moment, it's not possible to display **separate badges** for test, build, and deploy stages.  
 
 To achieve separate badges, we would need to **split the existing workflow into multiple workflows** dedicated to each stage.


_Screenshot of badge_:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/98b731ff-1dd9-4bc8-8e11-e1d98c954d9e" />



_The code coverage is indeed 0 as verified on sonarqube, refer ss:_

<img width="500" alt="image" src="https://github.com/user-attachments/assets/225f3c9c-9ec3-43ce-81a7-a96efd27685a" />
