### PR TITLE
fix: Remove cyclic dependency in user-menu-dropdown and other lint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,8 @@
     "import/resolver": {
       "node": {
         "extensions": [
+          ".js",
+          ".jsx",
           ".ts",
           ".tsx"
         ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,8 +13,6 @@
     "import/resolver": {
       "node": {
         "extensions": [
-          ".js",
-          ".jsx",
           ".ts",
           ".tsx"
         ]

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  //'*?(x)': () => 'npm run fmt',
+  // '*?(x)': () => 'npm run fmt',
   '*.{js,ts,tsx}': ['prettier --write --ignore-path .prettierignore'],
   '*.py': ['pipenv run autoflake -i', 'pipenv run isort', 'pipenv run black'],
 };

--- a/src/apps/frontend/app.component.tsx
+++ b/src/apps/frontend/app.component.tsx
@@ -1,14 +1,15 @@
 import { ErrorBoundary } from '@datadog/browser-rum-react';
-import { AccountProvider } from 'frontend/contexts';
-import { AuthProvider } from 'frontend/contexts/auth.provider';
-import { Config } from 'frontend/helpers';
-import { AppRoutes } from 'frontend/routes';
-import InspectLet from 'frontend/vendor/inspectlet';
 import React, { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 
 import { ErrorFallback } from './pages/error';
 import { Logger } from './utils/logger';
+
+import { AccountProvider } from 'frontend/contexts';
+import { AuthProvider } from 'frontend/contexts/auth.provider';
+import { Config } from 'frontend/helpers';
+import { AppRoutes } from 'frontend/routes';
+import InspectLet from 'frontend/vendor/inspectlet';
 
 Logger.init();
 

--- a/src/apps/frontend/components/button/index.tsx
+++ b/src/apps/frontend/components/button/index.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
+import React, { PropsWithChildren } from 'react';
+
 import Spinner from 'frontend/components/spinner/spinner';
 import { ButtonKind, ButtonType } from 'frontend/types/button';
-import React, { PropsWithChildren } from 'react';
 
 interface ButtonProps {
   disabled?: boolean;

--- a/src/apps/frontend/components/flex/flex-item.component.tsx
+++ b/src/apps/frontend/components/flex/flex-item.component.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
-import styles from 'frontend/components/flex/flex-item.styles';
 import React, { PropsWithChildren } from 'react';
+
+import styles from 'frontend/components/flex/flex-item.styles';
 
 interface FlexItemProps {
   alignSelf?: keyof typeof styles.alignSelf;

--- a/src/apps/frontend/components/flex/flex.component.tsx
+++ b/src/apps/frontend/components/flex/flex.component.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
-import styles from 'frontend/components/flex/flex.styles';
 import React, { PropsWithChildren } from 'react';
+
+import styles from 'frontend/components/flex/flex.styles';
 
 interface FlexProps {
   alignItems?: keyof typeof styles.alignItems;

--- a/src/apps/frontend/components/form-control/index.tsx
+++ b/src/apps/frontend/components/form-control/index.tsx
@@ -1,5 +1,6 @@
-import VerticalStackLayout from 'frontend/components/layouts/vertical-stack-layout';
 import React, { PropsWithChildren } from 'react';
+
+import VerticalStackLayout from 'frontend/components/layouts/vertical-stack-layout';
 
 interface FormControlProps {
   error?: string;

--- a/src/apps/frontend/components/header/index.tsx
+++ b/src/apps/frontend/components/header/index.tsx
@@ -1,15 +1,11 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import HamburgerToggleButton from 'frontend/components/header/hamburger-toggle-button';
 import UserProfileSnippet from 'frontend/components/header/user-profile-snippet.component';
 import routes from 'frontend/constants/routes';
 import { useAccountContext, useAuthContext } from 'frontend/contexts';
-import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
-
-export type UserMenuDropdownItem = {
-  iconPath: string;
-  label: string;
-  onClick: () => void;
-};
+import { UserMenuDropdownItem } from 'frontend/types';
 
 type HeaderProps = {
   isSidebarOpen: boolean;

--- a/src/apps/frontend/components/header/user-menu-dropdown.component.tsx
+++ b/src/apps/frontend/components/header/user-menu-dropdown.component.tsx
@@ -1,5 +1,6 @@
-import { UserMenuDropdownItem } from 'frontend/components/header';
 import React from 'react';
+
+import { UserMenuDropdownItem } from 'frontend/types';
 
 type UserMenuDropdownProps = {
   dropdownOpen: boolean;

--- a/src/apps/frontend/components/header/user-profile-snippet.component.tsx
+++ b/src/apps/frontend/components/header/user-profile-snippet.component.tsx
@@ -1,9 +1,9 @@
-import { UserMenuDropdownItem } from 'frontend/components/header';
-import UserMenuDropdown from 'frontend/components/header/user-menu-dropdown.component';
-import { Account } from 'frontend/types';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+
+import UserMenuDropdown from 'frontend/components/header/user-menu-dropdown.component';
+import { Account, UserMenuDropdownItem } from 'frontend/types';
 
 interface DropdownUserProps {
   account: Account;

--- a/src/apps/frontend/components/input/index.tsx
+++ b/src/apps/frontend/components/input/index.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
+import * as React from 'react';
+
 import HorizontalStackLayout from 'frontend/components/layouts/horizontal-stack-layout';
 import { Nullable } from 'frontend/types/common-types';
-import * as React from 'react';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   endEnhancer?: React.ReactElement | string;

--- a/src/apps/frontend/components/input/password-input.tsx
+++ b/src/apps/frontend/components/input/password-input.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from 'react';
+
 import Button from 'frontend/components/button';
 import Input from 'frontend/components/input/';
 import { ButtonKind } from 'frontend/types/button';
-import React, { useState } from 'react';
 
 interface PasswordInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/src/apps/frontend/components/layouts/custom-layout.component.tsx
+++ b/src/apps/frontend/components/layouts/custom-layout.component.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+
 import {
   LayoutConfig,
   LayoutType,
 } from 'frontend/components/layouts/layout-config';
-import React from 'react';
 
 interface CustomLayoutProps {
   layoutType?: LayoutType;

--- a/src/apps/frontend/components/otp/index.tsx
+++ b/src/apps/frontend/components/otp/index.tsx
@@ -1,7 +1,8 @@
+import React, { useRef, useState, FocusEventHandler } from 'react';
+
 import OTPInput from 'frontend/components/otp/otp-input';
 import constant from 'frontend/constants';
 import { AsyncError, KeyboardKeys } from 'frontend/types';
-import React, { useRef, useState, FocusEventHandler } from 'react';
 
 interface OTPProps {
   error?: string;

--- a/src/apps/frontend/components/otp/otp-hint.tsx
+++ b/src/apps/frontend/components/otp/otp-hint.tsx
@@ -1,5 +1,6 @@
-import InfoIcon from 'frontend/components/icons/info-icon';
 import React from 'react';
+
+import InfoIcon from 'frontend/components/icons/info-icon';
 
 interface OtpHintProps {
   otpCode?: string;

--- a/src/apps/frontend/components/otp/otp-input.tsx
+++ b/src/apps/frontend/components/otp/otp-input.tsx
@@ -1,5 +1,6 @@
-import Input from 'frontend/components/input';
 import React, { FocusEventHandler } from 'react';
+
+import Input from 'frontend/components/input';
 
 type OTPInputProps = {
   disabled: boolean;

--- a/src/apps/frontend/components/sidebar/index.tsx
+++ b/src/apps/frontend/components/sidebar/index.tsx
@@ -1,6 +1,7 @@
+import React, { useRef } from 'react';
+
 import SidebarMenuItem from 'frontend/components/sidebar/sidebar-menu-item';
 import routes from 'frontend/constants/routes';
-import React, { useRef } from 'react';
 
 type SidebarProps = {
   isSidebarOpen: boolean;

--- a/src/apps/frontend/contexts/account.provider.tsx
+++ b/src/apps/frontend/contexts/account.provider.tsx
@@ -1,10 +1,11 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+
 import useAsync from 'frontend/contexts/async.hook';
 import { AccountService } from 'frontend/services';
 import { Account, ApiResponse, AsyncError } from 'frontend/types';
 import { Nullable } from 'frontend/types/common-types';
 import { Logger } from 'frontend/utils/logger';
 import { getAccessTokenFromStorage } from 'frontend/utils/storage-util';
-import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 type AccountContextType = {
   accountDetails: Account;

--- a/src/apps/frontend/contexts/async.hook.ts
+++ b/src/apps/frontend/contexts/async.hook.ts
@@ -1,7 +1,8 @@
+import { useCallback, useState } from 'react';
+
 import { UseAsyncResponse, AsyncResult, AsyncError } from 'frontend/types';
 import { AsyncOperationError } from 'frontend/types/async-operation';
 import { Nullable } from 'frontend/types/common-types';
-import { useCallback, useState } from 'react';
 
 const useAsync = <T>(
   asyncFn: (...args: unknown[]) => Promise<AsyncResult<T>>,

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -1,3 +1,5 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+
 import useAsync from 'frontend/contexts/async.hook';
 import { AuthService } from 'frontend/services';
 import {
@@ -12,7 +14,6 @@ import {
   removeAccessTokenFromStorage,
   setAccessTokenToStorage,
 } from 'frontend/utils/storage-util';
-import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 type AuthContextType = {
   isLoginLoading: boolean;

--- a/src/apps/frontend/contexts/reset-password.provider.tsx
+++ b/src/apps/frontend/contexts/reset-password.provider.tsx
@@ -1,9 +1,10 @@
+import React, { createContext, PropsWithChildren, useContext } from 'react';
+
 import useAsync from 'frontend/contexts/async.hook';
 import { ResetPasswordParams } from 'frontend/pages/authentication/reset-password/reset-password-form.hook';
 import { ResetPasswordService } from 'frontend/services';
 import { ApiResponse, AsyncError } from 'frontend/types';
 import { Nullable } from 'frontend/types/common-types';
-import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 type ResetPasswordContextType = {
   isResetPasswordLoading: boolean;

--- a/src/apps/frontend/index.tsx
+++ b/src/apps/frontend/index.tsx
@@ -1,8 +1,9 @@
 import 'frontend/satoshi.css';
 import 'frontend/style.css';
-import App from 'frontend/app.component';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+
+import App from 'frontend/app.component';
 
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('app') as HTMLElement;

--- a/src/apps/frontend/pages/app-layout/app-layout.tsx
+++ b/src/apps/frontend/pages/app-layout/app-layout.tsx
@@ -1,6 +1,7 @@
+import React, { PropsWithChildren } from 'react';
+
 import { Header } from 'frontend/components';
 import Sidebar from 'frontend/components/sidebar';
-import React, { PropsWithChildren } from 'react';
 
 export const AppLayout: React.FC<PropsWithChildren> = ({ children }) => {
   const [isSidebarOpen, setIsSidebarOpen] = React.useState(false);

--- a/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
+++ b/src/apps/frontend/pages/authentication/authentication-form-layout.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import { CustomLayout } from 'frontend/components/layouts/custom-layout.component';
 import { LayoutType } from 'frontend/components/layouts/layout-config';
-import React from 'react';
 
 interface AuthenticationFormLayoutProps {
   children: React.ReactNode;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.hook.ts
@@ -1,8 +1,9 @@
 import { useFormik } from 'formik';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import { useResetPasswordContext } from 'frontend/contexts';
 import { AsyncError } from 'frontend/types';
-import * as Yup from 'yup';
 
 interface UseForgotPasswordFormProps {
   onSuccess: (newUsername: string) => void;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-form.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   Button,
   FormControl,
@@ -8,7 +10,6 @@ import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
 import useForgotPasswordForm from 'frontend/pages/authentication/forgot-password/forgot-password-form.hook';
 import { AsyncError } from 'frontend/types';
 import { ButtonType } from 'frontend/types/button';
-import React from 'react';
 
 interface ForgotPasswordFormProps {
   onError: (error: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/forgot-password/forgot-password-resend-email.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/forgot-password-resend-email.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+
 import { Button, Flex, VerticalStackLayout } from 'frontend/components';
 import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
 import { useResetPasswordContext } from 'frontend/contexts';
 import { AsyncError } from 'frontend/types';
 import { ButtonType } from 'frontend/types/button';
-import React from 'react';
 
 interface ForgotPasswordResendEmailProps {
   isResendEnabled: boolean;

--- a/src/apps/frontend/pages/authentication/forgot-password/index.tsx
+++ b/src/apps/frontend/pages/authentication/forgot-password/index.tsx
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
 import { Button, H2, VerticalStackLayout } from 'frontend/components';
 import routes from 'frontend/constants/routes';
 import AuthenticationPageLayout from 'frontend/pages/authentication//authentication-page-layout';
@@ -7,9 +11,6 @@ import ForgotPasswordResendEmail from 'frontend/pages/authentication/forgot-pass
 import { AsyncError } from 'frontend/types';
 import { ButtonKind } from 'frontend/types/button';
 import useTimer from 'frontend/utils/use-timer.hook';
-import React, { useState } from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
 
 export const ForgotPassword: React.FC = () => {
   const passwordResendDelayInSeconds = 60_000;

--- a/src/apps/frontend/pages/authentication/otp/index.tsx
+++ b/src/apps/frontend/pages/authentication/otp/index.tsx
@@ -1,3 +1,7 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
 import { Button, H2, VerticalStackLayout } from 'frontend/components';
 import constant from 'frontend/constants';
 import routes from 'frontend/constants/routes';
@@ -7,9 +11,6 @@ import OTPForm from 'frontend/pages/authentication/otp/otp-form';
 import { AsyncError } from 'frontend/types';
 import { ButtonKind } from 'frontend/types/button';
 import useTimer from 'frontend/utils/use-timer.hook';
-import React from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
 
 export const OTPVerificationPage: React.FC = () => {
   const { startTimer, remaininingSecondsStr, isResendEnabled } = useTimer({

--- a/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
+++ b/src/apps/frontend/pages/authentication/otp/otp-form-hook.ts
@@ -1,8 +1,9 @@
 import { useFormik } from 'formik';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import { useAuthContext } from 'frontend/contexts';
 import { AsyncError, PhoneNumber } from 'frontend/types';
-import * as Yup from 'yup';
 
 interface OTPFormProps {
   onError: (error: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/otp/otp-form.tsx
+++ b/src/apps/frontend/pages/authentication/otp/otp-form.tsx
@@ -1,3 +1,6 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import {
   Button,
   Flex,
@@ -11,8 +14,6 @@ import { Config } from 'frontend/helpers';
 import useOTPForm from 'frontend/pages/authentication/otp/otp-form-hook';
 import { AsyncError } from 'frontend/types';
 import { ButtonKind, ButtonType } from 'frontend/types/button';
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 interface OTPFormProps {
   isResendEnabled: boolean;

--- a/src/apps/frontend/pages/authentication/phone-login/index.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/index.tsx
@@ -1,10 +1,11 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+
 import { H2, VerticalStackLayout } from 'frontend/components';
 import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
 import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
 import PhoneLoginForm from 'frontend/pages/authentication/phone-login/phone-login-form';
 import { AsyncError } from 'frontend/types';
-import React from 'react';
-import toast from 'react-hot-toast';
 
 export const PhoneLogin: React.FC = () => {
   const onSendOTPSuccess = () => {

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.hook.ts
@@ -1,11 +1,12 @@
 import { useFormik } from 'formik';
+import { PhoneNumberUtil } from 'google-libphonenumber';
+import { useNavigate } from 'react-router-dom';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import routes from 'frontend/constants/routes';
 import { useAuthContext } from 'frontend/contexts';
 import { AsyncError, PhoneNumber } from 'frontend/types';
-import { PhoneNumberUtil } from 'google-libphonenumber';
-import { useNavigate } from 'react-router-dom';
-import * as Yup from 'yup';
 
 interface PhoneLoginFormProps {
   onError: (err: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   Button,
   Flex,
@@ -10,7 +12,6 @@ import COUNTRY_SELECT_OPTIONS from 'frontend/constants/countries';
 import usePhoneLoginForm from 'frontend/pages/authentication/phone-login/phone-login-form.hook';
 import { AsyncError } from 'frontend/types';
 import { ButtonKind, ButtonType } from 'frontend/types/button';
-import React from 'react';
 
 interface PhoneLoginFormProps {
   onSendOTPSuccess: () => void;

--- a/src/apps/frontend/pages/authentication/reset-password/index.tsx
+++ b/src/apps/frontend/pages/authentication/reset-password/index.tsx
@@ -1,3 +1,7 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
 import { H2, VerticalStackLayout } from 'frontend/components';
 import ParagraphMedium from 'frontend/components/typography/paragraph-medium';
 import routes from 'frontend/constants/routes';
@@ -5,9 +9,6 @@ import AuthenticationFormLayout from 'frontend/pages/authentication/authenticati
 import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
 import ResetPasswordForm from 'frontend/pages/authentication/reset-password/reset-password-form';
 import { AsyncError } from 'frontend/types';
-import React from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
 
 export const ResetPassword: React.FC = () => {
   const navigate = useNavigate();

--- a/src/apps/frontend/pages/authentication/reset-password/reset-password-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/reset-password/reset-password-form.hook.ts
@@ -1,9 +1,10 @@
 import { useFormik } from 'formik';
+import { useLocation, useParams } from 'react-router-dom';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import { useResetPasswordContext } from 'frontend/contexts';
 import { AsyncError } from 'frontend/types';
-import { useLocation, useParams } from 'react-router-dom';
-import * as Yup from 'yup';
 
 export type ResetPasswordParams = {
   accountId: string;

--- a/src/apps/frontend/pages/authentication/reset-password/reset-password-form.tsx
+++ b/src/apps/frontend/pages/authentication/reset-password/reset-password-form.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   Button,
   FormControl,
@@ -7,7 +9,6 @@ import {
 import useResetPasswordForm from 'frontend/pages/authentication/reset-password/reset-password-form.hook';
 import { AsyncError } from 'frontend/types';
 import { ButtonType } from 'frontend/types/button';
-import React from 'react';
 
 interface ResetPasswordFormProps {
   onSuccess: () => void;

--- a/src/apps/frontend/pages/authentication/signup/index.tsx
+++ b/src/apps/frontend/pages/authentication/signup/index.tsx
@@ -1,12 +1,13 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
 import { H2, VerticalStackLayout } from 'frontend/components';
 import routes from 'frontend/constants/routes';
 import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
 import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
 import SignupForm from 'frontend/pages/authentication/signup/signup-form';
 import { AsyncError } from 'frontend/types';
-import React from 'react';
-import toast from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
 
 export const Signup: React.FC = () => {
   const navigate = useNavigate();

--- a/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.hook.ts
@@ -1,8 +1,9 @@
 import { useFormik } from 'formik';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import { useAuthContext } from 'frontend/contexts';
 import { AsyncError } from 'frontend/types';
-import * as Yup from 'yup';
 
 interface SignupFormProps {
   onError: (err: AsyncError) => void;

--- a/src/apps/frontend/pages/authentication/signup/signup-form.tsx
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
 import {
   Button,
   Flex,
@@ -12,8 +15,6 @@ import routes from 'frontend/constants/routes';
 import useSignupForm from 'frontend/pages/authentication/signup/signup-form.hook';
 import { AsyncError } from 'frontend/types';
 import { ButtonKind, ButtonType } from 'frontend/types/button';
-import React from 'react';
-import { Link } from 'react-router-dom';
 
 type SignupFields =
   | 'firstName'

--- a/src/apps/frontend/pages/error/index.tsx
+++ b/src/apps/frontend/pages/error/index.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import { Button, H2, ParagraphMedium } from 'frontend/components';
 import { ButtonKind } from 'frontend/types/button';
-import React from 'react';
 
 type ErrorFallbackProps = {
   error: Error;

--- a/src/apps/frontend/pages/login/index.tsx
+++ b/src/apps/frontend/pages/login/index.tsx
@@ -1,13 +1,14 @@
-import { VerticalStackLayout, H2 } from 'frontend/components';
-import routes from 'frontend/constants/routes';
-import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
-import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
-import { AsyncError } from 'frontend/types';
 import React from 'react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
 import LoginForm from './login-form';
+
+import { VerticalStackLayout, H2 } from 'frontend/components';
+import routes from 'frontend/constants/routes';
+import AuthenticationFormLayout from 'frontend/pages/authentication/authentication-form-layout';
+import AuthenticationPageLayout from 'frontend/pages/authentication/authentication-page-layout';
+import { AsyncError } from 'frontend/types';
 
 export const Login: React.FC = () => {
   const navigate = useNavigate();

--- a/src/apps/frontend/pages/login/login-form.hook.ts
+++ b/src/apps/frontend/pages/login/login-form.hook.ts
@@ -1,8 +1,9 @@
 import { useFormik } from 'formik';
+import * as Yup from 'yup';
+
 import constant from 'frontend/constants';
 import { useAuthContext } from 'frontend/contexts';
 import { AsyncError } from 'frontend/types';
-import * as Yup from 'yup';
 
 interface LoginFormProps {
   onSuccess: () => void;

--- a/src/apps/frontend/pages/login/login-form.tsx
+++ b/src/apps/frontend/pages/login/login-form.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
 import { AsyncError } from 'frontend//types';
 import {
   VerticalStackLayout,
@@ -13,8 +16,6 @@ import routes from 'frontend/constants/routes';
 import LoginFormCheckbox from 'frontend/pages/login/login-form-checkbox';
 import useLoginForm from 'frontend/pages/login/login-form.hook';
 import { ButtonType, ButtonKind } from 'frontend/types/button';
-import React from 'react';
-import { Link } from 'react-router-dom';
 
 type LoginFields = 'username' | 'password';
 

--- a/src/apps/frontend/routes/index.tsx
+++ b/src/apps/frontend/routes/index.tsx
@@ -1,9 +1,10 @@
 import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v6';
+import React from 'react';
+import { RouterProvider } from 'react-router-dom';
+
 import { useAuthContext } from 'frontend/contexts';
 import { protectedRoutes } from 'frontend/routes/protected';
 import { publicRoutes } from 'frontend/routes/public';
-import React from 'react';
-import { RouterProvider } from 'react-router-dom';
 
 export const AppRoutes = () => {
   const { isUserAuthenticated } = useAuthContext();

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -1,11 +1,12 @@
+import React, { useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { Outlet, useNavigate } from 'react-router-dom';
+
 import routes from 'frontend/constants/routes';
 import { useAccountContext, useAuthContext } from 'frontend/contexts';
 import { Dashboard, NotFound } from 'frontend/pages';
 import AppLayout from 'frontend/pages/app-layout/app-layout';
 import { AsyncError } from 'frontend/types';
-import React, { useEffect } from 'react';
-import toast from 'react-hot-toast';
-import { Outlet, useNavigate } from 'react-router-dom';
 
 const App = () => {
   const { getAccountDetails } = useAccountContext();

--- a/src/apps/frontend/routes/public.tsx
+++ b/src/apps/frontend/routes/public.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
 import constant from 'frontend/constants';
 import routes from 'frontend/constants/routes';
 import { ResetPasswordProvider } from 'frontend/contexts';
@@ -11,8 +14,6 @@ import {
   ResetPassword,
   Signup,
 } from 'frontend/pages';
-import React from 'react';
-import { Navigate } from 'react-router-dom';
 
 const currentAuthMechanism = Config.getConfigValue<string>(
   'authenticationMechanism',

--- a/src/apps/frontend/services/api.service.ts
+++ b/src/apps/frontend/services/api.service.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from 'axios';
+
 import AppService from 'frontend/services/app.service';
 
 export default class APIService extends AppService {

--- a/src/apps/frontend/types/index.ts
+++ b/src/apps/frontend/types/index.ts
@@ -1,3 +1,5 @@
+import { DatadogUser } from './logger';
+
 import { Account } from 'frontend/types/account';
 import {
   AsyncError,
@@ -6,8 +8,7 @@ import {
 } from 'frontend/types/async-operation';
 import { AccessToken, KeyboardKeys, PhoneNumber } from 'frontend/types/auth';
 import { ApiResponse, ApiError } from 'frontend/types/service-response';
-
-import { DatadogUser } from './logger';
+import { UserMenuDropdownItem } from 'frontend/types/user-menu-dropdown-item';
 
 export {
   AccessToken,
@@ -20,4 +21,5 @@ export {
   PhoneNumber,
   UseAsyncResponse,
   DatadogUser,
+  UserMenuDropdownItem,
 };

--- a/src/apps/frontend/types/user-menu-dropdown-item.ts
+++ b/src/apps/frontend/types/user-menu-dropdown-item.ts
@@ -1,0 +1,5 @@
+export type UserMenuDropdownItem = {
+  iconPath: string;
+  label: string;
+  onClick: () => void;
+};

--- a/src/apps/frontend/utils/logger.ts
+++ b/src/apps/frontend/utils/logger.ts
@@ -6,6 +6,7 @@ import {
   RumInitConfiguration,
 } from '@datadog/browser-rum';
 import { reactPlugin } from '@datadog/browser-rum-react';
+
 import getConfigValue from 'frontend/helpers/config';
 import { DatadogUser } from 'frontend/types';
 

--- a/src/apps/frontend/webpack.base.js
+++ b/src/apps/frontend/webpack.base.js
@@ -1,8 +1,9 @@
-const config = require('config');
 const path = require('path');
-const webpack = require('webpack');
+
+const config = require('config');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
 
 const webpackBuildConfig = JSON.stringify(
   config.util.toObject(config.has('public') ? config.get('public') : {}),


### PR DESCRIPTION
## Description
_This PR does two things._

1. Run `npm run lint:fix` to arrange import orders and fix autofixable lint errors
2. Resolve cyclic dependency error between `src/apps/frontend/components/header/user-menu-dropdown.component.tsx` and `src/apps/frontend/components/header/user-profile-snippet.component.tsx`