### PR TITLE
feat: enable environment variable control for OTP testing configuration

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -29,6 +29,9 @@ twilio:
   messaging_service_sid: 'TWILIO_MESSAGING_SERVICE_SID'
 
 public:
+  default_otp:                          
+    enabled: 'DEFAULT_OTP_ENABLED'      
+    code: 'DEFAULT_OTP'                 
   datadog:
     applicationId: 'DATADOG_APPLICATION_ID'
     clientToken: 'DATADOG_CLIENT_TOKEN'

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -29,9 +29,11 @@ twilio:
   messaging_service_sid: 'TWILIO_MESSAGING_SERVICE_SID'
 
 public:
-  default_otp:                          
-    enabled: 'DEFAULT_OTP_ENABLED'      
-    code: 'DEFAULT_OTP'                 
+  default_otp:
+    enabled:
+      __name: 'DEFAULT_OTP_ENABLED'
+      __format: 'boolean'
+    code: 'DEFAULT_OTP_CODE'                 
   datadog:
     applicationId: 'DATADOG_APPLICATION_ID'
     clientToken: 'DATADOG_CLIENT_TOKEN'


### PR DESCRIPTION
## Description

Merging this PR will let us toggle the default OTP feature without modifying `production.yaml`. Instead, we add `default_otp.enabled` and `default_otp.code` to `config/custom-environment-variables.yml`, mapping them to the environment variables `DEFAULT_OTP_ENABLED` and `DEFAULT_OTP`.

This allows us to control whether a static test OTP is active **directly through Doppler**. During testing, we can set `DEFAULT_OTP_ENABLED=true` to bypass Twilio and use a static OTP. After testing, we simply reset it to `false`—ensuring real users never receive the default OTP in production.

**Key Changes:**

* Added `public.default_otp.enabled` and `public.default_otp.code` mappings in `custom-environment-variables.yml`
* Enables runtime control over default OTP behavior via environment variables without code changes or redeployment



## Database schema changes

No database schema changes are included in this PR.

## Tests

### Automated test cases added

* No new automated tests (configuration-only change)

### Manual test cases run

* **Test with default OTP enabled**:

  1. Set `DEFAULT_OTP_ENABLED=true` and `DEFAULT_OTP=1234` in Doppler
  2. Call `/api/accounts` with a phone number
  3. Confirm account creation succeeds without Twilio credentials
  4. Call `/api/access-tokens` with the phone number and OTP `1234`
  5. Confirm authentication succeeds and returns an access token
* **Verify config loads correctly**:

  1. Deploy the app with new config
  2. Ensure `public.default_otp.enabled` and `public.default_otp.code` correctly reflect the environment variables
* **Test backward compatibility**:

  1. Check existing env var mappings continue to work
  2. Confirm no changes to unrelated configuration
