### PR TITLE
(testing) : Disable default OTP and remove hardcoded code

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -29,6 +29,9 @@ twilio:
   messaging_service_sid: 'TWILIO_MESSAGING_SERVICE_SID'
 
 public:
+  default_otp:                          
+    enabled: 'DEFAULT_OTP_ENABLED'      
+    code: 'DEFAULT_OTP'                 
   datadog:
     applicationId: 'DATADOG_APPLICATION_ID'
     clientToken: 'DATADOG_CLIENT_TOKEN'

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -29,9 +29,11 @@ twilio:
   messaging_service_sid: 'TWILIO_MESSAGING_SERVICE_SID'
 
 public:
-  default_otp:                          
-    enabled: 'DEFAULT_OTP_ENABLED'      
-    code: 'DEFAULT_OTP'                 
+  default_otp:
+    enabled:
+      __name: 'DEFAULT_OTP_ENABLED'
+      __format: 'boolean'
+    code: 'DEFAULT_OTP_CODE'                 
   datadog:
     applicationId: 'DATADOG_APPLICATION_ID'
     clientToken: 'DATADOG_CLIENT_TOKEN'

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -10,5 +10,3 @@ is_server_running_behind_proxy: true
 
 public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
-  default_otp:
-    enabled: false

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -11,5 +11,4 @@ is_server_running_behind_proxy: true
 public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
   default_otp:
-    enabled: true
-    code: '1234'
+    enabled: false


### PR DESCRIPTION
- Set `default_otp.enabled` to `false` to prevent automatic acceptance of a static OTP.
- Removed the hardcoded `default_otp.code` value to avoid security risks.

## Description
_A few sentences describing the overall goals of the pull request's commits. In case you are creating or updating new endpoints, please document request, response schema._

## Database schema changes
_Please document any change in database schema made part of this PR._

## Tests
### Automated test cases added
- _Description of automated test 1_
- _Description of automated test 2_
- _Description of automated test 3_

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- _Description of manual test 1_
- _Description of manual test 2_
- _Description of manual test 3_
