### PR TITLE
test: Add test phone number whitelist for OTP handling

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -38,3 +38,8 @@ public:
     sessionReplaySampleRate: 'DATADOG_SESSION_REPLAY_SAMPLE_RATE'
     sessionSampleRate: 'DATADOG_SESSION_SAMPLE_RATE'
     site: 'DATADOG_SITE'
+  default_otp:
+    code: 'DEFAULT_OTP_CODE'
+  test_whitelist:
+    enabled: 'TEST_WHITELIST_ENABLED'
+    phone_numbers: 'TEST_WHITELIST_PHONE_NUMBERS'

--- a/config/default.yml
+++ b/config/default.yml
@@ -20,3 +20,6 @@ public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
   datadog:
     enabled: 'false'
+  test_whitelist:
+    enabled: false
+    phone_numbers: []

--- a/config/development.yml
+++ b/config/development.yml
@@ -17,3 +17,8 @@ public:
   default_otp:
     enabled: true
     code: '1234'
+  test_whitelist:
+    enabled: true
+    phone_numbers:
+      - '+919999999999'
+      - '+911234567890'

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -17,3 +17,8 @@ public:
   default_otp:
     enabled: true
     code: '1234'
+  test_whitelist:
+    enabled: true
+    phone_numbers:
+      - '+919999999999'
+      - '+911234567890'

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -10,6 +10,3 @@ is_server_running_behind_proxy: true
 
 public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
-  default_otp:
-    enabled: true
-    code: '1234'

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -11,3 +11,13 @@ mailer:
 
 sms:
   enabled: false
+
+public:
+  test_whitelist:
+    enabled: true
+    phone_numbers:
+      - '+919999999999'
+      - '+911234567890'
+  default_otp:
+    enabled: true
+    code: '1234'

--- a/src/apps/backend/modules/authentication/internals/otp/otp_util.py
+++ b/src/apps/backend/modules/authentication/internals/otp/otp_util.py
@@ -1,6 +1,6 @@
 import secrets
 import string
-from typing import Any
+from typing import Any, List
 
 from modules.authentication.internals.otp.store.otp_model import OTPModel
 from modules.authentication.types import OTP
@@ -11,10 +11,45 @@ class OTPUtil:
 
     @staticmethod
     def generate_otp(length: int, phone_number: str) -> str:
-        if OTPUtil.is_default_otp_enabled():
+        if OTPUtil.should_use_default_otp(phone_number):
             default_otp = ConfigService[str].get_value(key="public.default_otp.code")
             return default_otp
         return "".join(secrets.choice(string.digits) for _ in range(length))
+
+    @staticmethod
+    def should_use_default_otp(phone_number: str) -> bool:
+        is_whitelist_enabled = ConfigService[bool].get_value(key="public.test_whitelist.enabled", default=False)
+
+        if is_whitelist_enabled:
+            return OTPUtil.is_phone_number_whitelisted(phone_number)
+        else:
+            return OTPUtil.is_default_otp_enabled()
+
+    @staticmethod
+    def is_phone_number_whitelisted(phone_number: str) -> bool:
+        whitelist_numbers = ConfigService[List[str]].get_value(key="public.test_whitelist.phone_numbers", default=[])
+
+        normalized_input = phone_number.replace(" ", "").replace("-", "")
+
+        for whitelisted_number in whitelist_numbers:
+            normalized_whitelist = whitelisted_number.replace(" ", "").replace("-", "")
+            if normalized_input == normalized_whitelist:
+                return True
+
+        return False
+
+    @staticmethod
+    def should_send_sms(phone_number: str) -> bool:
+        from modules.config.config_service import ConfigService
+
+        is_sms_enabled = ConfigService[bool].get_value(key="sms.enabled", default=True)
+        if not is_sms_enabled:
+            return False
+
+        if OTPUtil.should_use_default_otp(phone_number):
+            return False
+
+        return True
 
     @staticmethod
     def convert_otp_bson_to_otp(otp_bson: dict[str, Any]) -> OTP:

--- a/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
+++ b/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
@@ -24,7 +24,8 @@ class OTPWriter:
     def create_new_otp(*, params: CreateOTPParams) -> OTP:
         OTPWriter.expire_previous_otps(phone_number=params.phone_number)
         phone_number = PhoneNumber(**asdict(params)["phone_number"])
-        otp_code = OTPUtil.generate_otp(length=4, phone_number=phone_number.phone_number)
+        full_phone_number = str(phone_number)
+        otp_code = OTPUtil.generate_otp(length=4, phone_number=full_phone_number)
         otp_bson = OTPModel(
             active=True, id=None, phone_number=phone_number, otp_code=otp_code, status=str(OTPStatus.PENDING)
         ).to_bson()

--- a/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
+++ b/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
@@ -29,7 +29,10 @@ class CustomEnvConfig:
             elif isinstance(value, str):
                 result = CustomEnvConfig._search_and_get_str_value_from_env(value)
                 if result is not None:
-                    updated_data[key] = result
+                    if key == "phone_numbers":
+                        updated_data[key] = CustomEnvConfig._parse_phone_numbers_list(result)
+                    else:
+                        updated_data[key] = result
 
         return updated_data
 
@@ -64,3 +67,11 @@ class CustomEnvConfig:
             return parser(value)
         except Exception as e:
             raise ValueError(f"Error parsing value '{value}' as {value_format}: {e}") from e
+
+    @staticmethod
+    def _parse_phone_numbers_list(phone_numbers_str: str) -> list[str]:
+        if not phone_numbers_str or phone_numbers_str.strip() == "":
+            return []
+
+        phone_numbers = [phone.strip() for phone in phone_numbers_str.split(",")]
+        return [phone for phone in phone_numbers if phone]


### PR DESCRIPTION
- Introduced `test_whitelist` config to selectively use default OTP codes for whitelisted phone numbers.
- Enhanced `OTPUtil` to check if a number is whitelisted before generating OTP or sending SMS.
- Adjusted SMS sending: now skips sending if default OTP is used or SMS is disabled.
- Added logic to normalize phone numbers when checking against whitelist for consistency.
- Enabled parsing comma-separated phone numbers from environment variables for easier configuration across environments.

## Description
_A few sentences describing the overall goals of the pull request's commits. In case you are creating or updating new endpoints, please document request, response schema._

## Database schema changes
_Please document any change in database schema made part of this PR._

## Tests
### Automated test cases added
- _Description of automated test 1_
- _Description of automated test 2_
- _Description of automated test 3_

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- _Description of manual test 1_
- _Description of manual test 2_
- _Description of manual test 3_
