### PR TITLE
fix: standardize app naming across environments in workflows

### DIFF
--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       # ENV-BASED provider selection
       hosting_provider: ${{ vars.HOSTING_PROVIDER }}  # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       branch: ${{ github.event.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       branch: ${{ github.event.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       branch: ${{ github.event.pull_request.head.ref }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -13,7 +13,7 @@ jobs:
       cancel-in-progress: true
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       app_hostname: preview.flask-react-template.platform.bettrhq.com
       branch: main

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       app_hostname: '{1}.preview.platform.bettrhq.com'
       branch: ${{ github.event.ref }}

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
       analyze_base: main
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: preview
       app_hostname: '{1}.preview.platform.bettrhq.com'
       branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -13,7 +13,7 @@ jobs:
       cancel-in-progress: true
     with:
       hosting_provider: ${{ vars.HOSTING_PROVIDER }} # 'DIGITAL_OCEAN' or 'AWS'
-      app_name: flask-react-template
+      app_name: flask-react-app
       app_env: production
       app_hostname: flask-react-template.platform.bettrhq.com
       branch: ${{ github.event.ref }}


### PR DESCRIPTION
## Description
_This Pull Request updates the app naming convention to ensure consistency across all environments **preview and production**_

- The workflow and manifest references now use a shorter, standardized name — `flask-react-app` — for better readability and easier maintenance.
- Previously, longer names (such as `flask-react-template-production-b28b7af69320201-deployment`) were causing Kubernetes metadata name limit exceedance, especially for CronJob and Job resources where Kubernetes automatically appends random suffixes.
To prevent future deployment failures and ensure namespace clarity, the app name has been shortened and unified across all configurations.
## Database schema changes
_NA._

## Tests
### Automated test cases

- Verified that all Kubernetes resources (pods, deployments, services, cronjobs) are created successfully under both preview namespace without exceeding name length limits.

- Validated that workflow executions correctly reference and deploy the updated app name (`flask-react-app`) across environments, and no broken resource dependencies occur.