### PR TITLE
security: replacing pull_request_target 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,14 +160,6 @@ jobs:
           
           echo "FILTERED_FILES=$FILTERED_FILES" >> $GITHUB_OUTPUT
       
-      - name: Format Deployment Files
-        run: | 
-          export KUBE_DEPLOYMENT_IMAGE=flask-react-app:${{ steps.extract_branch.outputs.branch_hash }}@sha256:123
-          for file in iac_changed_files/lib/kube/{preview,production,shared}/*.yaml; do
-            tmpfile=$(mktemp)
-            envsubst < "$file" > "$tmpfile" && mv "$tmpfile" "$file"
-          done
-
       - name: Run Trivy scan on IaC
         if: ${{ steps.iac_changes.outputs.FILTERED_FILES != '' }}
         id: trivy_iac


### PR DESCRIPTION
**Why these changes needed**
The previous cleanup workflow used pull_request_target, which is known to create security risks. Although GitHub Actions prevents direct printing of secrets through echo or file output, the workflow still runs with the privileges and secrets of the base branch while executing code from the pull request. This makes the pattern unsafe for workflows that perform deployments, environment cleanup, or any other sensitive operation.

Another practical issue is that pull_request_target does not use the workflow content from the feature branch.
Every run always uses the workflow from main.So if any new change is added to the cleanup workflow itself, you cannot test it on a feature branch — the only way to test is to merge it into main, which is not an acceptable or safe development practice.


**What changes done** 
Replace pull_request_target with pull_request making 

- the workflow runs against the code and workflow definitions in the PR branch
- untrusted PRs cannot execute privileged code using secrets
- workflow changes can be tested safely before merging

**Manuall testing done** 
**1)Added the echo steps for printing github secrets by directly commiting in main branch**
Github-action does not allow printing secert and replace with *
<img width="963" height="292" alt="image" src="https://github.com/user-attachments/assets/010d93d9-8e57-463f-aff9-8d5c82ee5f21" />

Loom video : https://www.loom.com/share/08f690e1e69b430a8abf0139fea47470