### PR TITLE
fix: remove format deployment file from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,14 +160,6 @@ jobs:
           
           echo "FILTERED_FILES=$FILTERED_FILES" >> $GITHUB_OUTPUT
       
-      - name: Format Deployment Files
-        run: | 
-          export KUBE_DEPLOYMENT_IMAGE=flask-react-app:${{ steps.extract_branch.outputs.branch_hash }}@sha256:123
-          for file in iac_changed_files/lib/kube/{preview,production,shared}/*.yaml; do
-            tmpfile=$(mktemp)
-            envsubst < "$file" > "$tmpfile" && mv "$tmpfile" "$file"
-          done
-
       - name: Run Trivy scan on IaC
         if: ${{ steps.iac_changes.outputs.FILTERED_FILES != '' }}
         id: trivy_iac


### PR DESCRIPTION
## Description
In this PR we are removing `Format Deployment Files` from ci.yml as it breaks our ci if there are no changes in k8s manifests