### PR TITLE
Task 1: Implement task comments CRUD API and tests

### DIFF
--- a/src/apps/backend/modules/task/internal/store/task_model.py
+++ b/src/apps/backend/modules/task/internal/store/task_model.py
@@ -16,6 +16,7 @@ class TaskModel(BaseModel):
     created_at: Optional[datetime] = datetime.now()
     id: Optional[ObjectId | str] = None
     updated_at: Optional[datetime] = datetime.now()
+    comments: Optional[list[dict]] = None
 
     @classmethod
     def from_bson(cls, bson_data: dict) -> "TaskModel":
@@ -27,6 +28,7 @@ class TaskModel(BaseModel):
             id=bson_data.get("_id"),
             title=bson_data.get("title", ""),
             updated_at=bson_data.get("updated_at"),
+            comments=bson_data.get("comments"),
         )
 
     @staticmethod

--- a/src/apps/backend/modules/task/rest_api/task_comment_router.py
+++ b/src/apps/backend/modules/task/rest_api/task_comment_router.py
@@ -1,0 +1,19 @@
+from flask import Blueprint
+
+from modules.task.rest_api.task_comment_view import TaskCommentView
+
+
+class TaskCommentRouter:
+    @staticmethod
+    def create_route(*, blueprint: Blueprint) -> Blueprint:
+        blueprint.add_url_rule(
+            "/accounts/<string:account_id>/tasks/<string:task_id>/comments",
+            view_func=TaskCommentView.as_view("task_comments"),
+            methods=["POST", "GET"],
+        )
+        blueprint.add_url_rule(
+            "/accounts/<string:account_id>/tasks/<string:task_id>/comments/<string:comment_id>",
+            view_func=TaskCommentView.as_view("task_comment_by_id"),
+            methods=["GET", "PATCH", "DELETE"],
+        )
+        return blueprint

--- a/src/apps/backend/modules/task/rest_api/task_comment_view.py
+++ b/src/apps/backend/modules/task/rest_api/task_comment_view.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+from typing import Optional
+
+from bson.objectid import ObjectId
+from flask import jsonify, request
+from flask.typing import ResponseReturnValue
+from flask.views import MethodView
+
+from modules.authentication.rest_api.access_auth_middleware import access_auth_middleware
+from modules.task.errors import TaskBadRequestError, TaskNotFoundError
+from modules.task.internal.store.task_repository import TaskRepository
+
+
+class TaskCommentView(MethodView):
+    @access_auth_middleware
+    def post(self, account_id: str, task_id: str) -> ResponseReturnValue:
+        request_data = request.get_json()
+        if request_data is None:
+            raise TaskBadRequestError("Request body is required")
+        text = request_data.get("text")
+        if not text:
+            raise TaskBadRequestError("Text is required")
+
+        task_bson = TaskRepository.collection().find_one(
+            {
+                "_id": ObjectId(task_id),
+                "account_id": account_id,
+                "active": True,
+            }
+        )
+        if task_bson is None:
+            raise TaskNotFoundError(task_id=task_id)
+
+        now = datetime.now()
+        comment_id = str(ObjectId())
+        new_comment = {
+            "id": comment_id,
+            "text": text,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        TaskRepository.collection().update_one(
+            {"_id": ObjectId(task_id), "comments": None},
+            {"$set": {"comments": []}},
+        )
+
+        TaskRepository.collection().update_one(
+            {"_id": ObjectId(task_id)},
+            {
+                "$push": {"comments": new_comment},
+                "$set": {"updated_at": now},
+            },
+        )
+
+        response_comment = {
+            "id": comment_id,
+            "task_id": task_id,
+            "account_id": account_id,
+            "text": text,
+        }
+        return jsonify(response_comment), 201
+
+    @access_auth_middleware
+    def get(
+        self,
+        account_id: str,
+        task_id: str,
+        comment_id: Optional[str] = None,
+    ) -> ResponseReturnValue:
+        task_bson = TaskRepository.collection().find_one(
+            {
+                "_id": ObjectId(task_id),
+                "account_id": account_id,
+                "active": True,
+            }
+        )
+        if task_bson is None:
+            raise TaskNotFoundError(task_id=task_id)
+
+        comments = task_bson.get("comments") or []
+
+        if comment_id is not None:
+            for comment in comments:
+                if comment.get("id") == comment_id:
+                    response_comment = {
+                        "id": comment.get("id"),
+                        "task_id": task_id,
+                        "account_id": account_id,
+                        "text": comment.get("text", ""),
+                    }
+                    return jsonify(response_comment), 200
+            raise TaskNotFoundError(task_id=task_id)
+
+        items = [
+            {
+                "id": comment.get("id"),
+                "task_id": task_id,
+                "account_id": account_id,
+                "text": comment.get("text", ""),
+            }
+            for comment in comments
+        ]
+        response_data = {
+            "items": items,
+            "total_count": len(items),
+        }
+        return jsonify(response_data), 200
+
+    @access_auth_middleware
+    def patch(
+        self,
+        account_id: str,
+        task_id: str,
+        comment_id: str,
+    ) -> ResponseReturnValue:
+        request_data = request.get_json()
+        if request_data is None:
+            raise TaskBadRequestError("Request body is required")
+        text = request_data.get("text")
+        if not text:
+            raise TaskBadRequestError("Text is required")
+
+        now = datetime.now()
+        result = TaskRepository.collection().update_one(
+            {
+                "_id": ObjectId(task_id),
+                "account_id": account_id,
+                "active": True,
+                "comments.id": comment_id,
+            },
+            {
+                "$set": {
+                    "comments.$.text": text,
+                    "comments.$.updated_at": now,
+                    "updated_at": now,
+                }
+            },
+        )
+
+        if result.matched_count == 0:
+            raise TaskNotFoundError(task_id=task_id)
+
+        task_bson = TaskRepository.collection().find_one(
+            {
+                "_id": ObjectId(task_id),
+                "account_id": account_id,
+                "active": True,
+            }
+        )
+        if task_bson is None:
+            raise TaskNotFoundError(task_id=task_id)
+
+        comments = task_bson.get("comments") or []
+        updated_comment = None
+        for comment in comments:
+            if comment.get("id") == comment_id:
+                updated_comment = comment
+                break
+
+        if updated_comment is None:
+            raise TaskNotFoundError(task_id=task_id)
+
+        response_comment = {
+            "id": updated_comment.get("id"),
+            "task_id": task_id,
+            "account_id": account_id,
+            "text": updated_comment.get("text", ""),
+        }
+        return jsonify(response_comment), 200
+
+    @access_auth_middleware
+    def delete(
+        self,
+        account_id: str,
+        task_id: str,
+        comment_id: str,
+    ) -> ResponseReturnValue:
+        TaskRepository.collection().update_one(
+            {"_id": ObjectId(task_id), "comments": None},
+            {"$set": {"comments": []}},
+        )
+
+        result = TaskRepository.collection().update_one(
+            {
+                "_id": ObjectId(task_id),
+                "account_id": account_id,
+                "active": True,
+            },
+            {
+                "$pull": {"comments": {"id": comment_id}},
+            },
+        )
+
+        if result.matched_count == 0 or result.modified_count == 0:
+            raise TaskNotFoundError(task_id=task_id)
+
+        return "", 204

--- a/src/apps/backend/modules/task/rest_api/task_rest_api_server.py
+++ b/src/apps/backend/modules/task/rest_api/task_rest_api_server.py
@@ -1,10 +1,13 @@
 from flask import Blueprint
 
 from modules.task.rest_api.task_router import TaskRouter
+from modules.task.rest_api.task_comment_router import TaskCommentRouter
 
 
 class TaskRestApiServer:
     @staticmethod
     def create() -> Blueprint:
         task_api_blueprint = Blueprint("task", __name__)
-        return TaskRouter.create_route(blueprint=task_api_blueprint)
+        TaskRouter.create_route(blueprint=task_api_blueprint)
+        TaskCommentRouter.create_route(blueprint=task_api_blueprint)
+        return task_api_blueprint

--- a/src/apps/backend/modules/task/types.py
+++ b/src/apps/backend/modules/task/types.py
@@ -58,3 +58,41 @@ class TaskDeletionResult:
 class TaskErrorCode:
     NOT_FOUND: str = "TASK_ERR_01"
     BAD_REQUEST: str = "TASK_ERR_02"
+
+
+@dataclass(frozen=True)
+class Comment:
+    id: str
+    task_id: str
+    account_id: str
+    text: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CreateCommentParams:
+    account_id: str
+    task_id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class UpdateCommentParams:
+    account_id: str
+    task_id: str
+    comment_id: str
+    text: str
+
+
+@dataclass(frozen=True)
+class DeleteCommentParams:
+    account_id: str
+    task_id: str
+    comment_id: str
+
+
+@dataclass(frozen=True)
+class GetCommentsForTaskParams:
+    account_id: str
+    task_id: str

--- a/tests/modules/task/test_task_comment_api.py
+++ b/tests/modules/task/test_task_comment_api.py
@@ -1,0 +1,425 @@
+import json
+
+from server import app
+from modules.authentication.types import AccessTokenErrorCode
+from modules.task.types import TaskErrorCode
+from tests.modules.task.base_test_task import BaseTestTask
+
+
+class TestTaskCommentApi(BaseTestTask):
+    def get_comment_api_url(self, account_id: str, task_id: str) -> str:
+        return f"http://127.0.0.1:8080/api/accounts/{account_id}/tasks/{task_id}/comments"
+
+    def get_comment_by_id_api_url(self, account_id: str, task_id: str, comment_id: str) -> str:
+        return f"{self.get_comment_api_url(account_id, task_id)}/{comment_id}"
+
+    def make_authenticated_comment_request(
+        self,
+        method: str,
+        account_id: str,
+        task_id: str,
+        token: str,
+        comment_id: str | None = None,
+        data: dict | None = None,
+    ):
+        if comment_id:
+            url = self.get_comment_by_id_api_url(account_id, task_id, comment_id)
+        else:
+            url = self.get_comment_api_url(account_id, task_id)
+        headers = {**self.HEADERS, "Authorization": f"Bearer {token}"}
+        with app.test_client() as client:
+            if method.upper() == "GET":
+                return client.get(url, headers={"Authorization": f"Bearer {token}"})
+            elif method.upper() == "POST":
+                return client.post(
+                    url,
+                    headers=headers,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "PATCH":
+                return client.patch(
+                    url,
+                    headers=headers,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "DELETE":
+                return client.delete(url, headers={"Authorization": f"Bearer {token}"})
+
+    def make_unauthenticated_comment_request(
+        self,
+        method: str,
+        account_id: str,
+        task_id: str,
+        comment_id: str | None = None,
+        data: dict | None = None,
+    ):
+        if comment_id:
+            url = self.get_comment_by_id_api_url(account_id, task_id, comment_id)
+        else:
+            url = self.get_comment_api_url(account_id, task_id)
+        with app.test_client() as client:
+            if method.upper() == "GET":
+                return client.get(url)
+            elif method.upper() == "POST":
+                return client.post(
+                    url,
+                    headers=self.HEADERS,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "PATCH":
+                return client.patch(
+                    url,
+                    headers=self.HEADERS,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "DELETE":
+                return client.delete(url)
+
+    def make_cross_account_comment_request(
+        self,
+        method: str,
+        target_account_id: str,
+        task_id: str,
+        auth_token: str,
+        comment_id: str | None = None,
+        data: dict | None = None,
+    ):
+        if comment_id:
+            url = self.get_comment_by_id_api_url(target_account_id, task_id, comment_id)
+        else:
+            url = self.get_comment_api_url(target_account_id, task_id)
+        headers = {**self.HEADERS, "Authorization": f"Bearer {auth_token}"}
+        with app.test_client() as client:
+            if method.upper() == "GET":
+                return client.get(url, headers={"Authorization": f"Bearer {auth_token}"})
+            elif method.upper() == "POST":
+                return client.post(
+                    url,
+                    headers=headers,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "PATCH":
+                return client.patch(
+                    url,
+                    headers=headers,
+                    data=json.dumps(data) if data is not None else None,
+                )
+            elif method.upper() == "DELETE":
+                return client.delete(
+                    url,
+                    headers={"Authorization": f"Bearer {auth_token}"},
+                )
+
+    def test_create_comment_success(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data = {"text": "First comment"}
+        response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data=data,
+        )
+        assert response.status_code == 201
+        assert response.json is not None
+        assert response.json.get("id") is not None
+        assert response.json.get("task_id") == task.id
+        assert response.json.get("account_id") == account.id
+        assert response.json.get("text") == "First comment"
+
+    def test_create_comment_missing_text(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data = {}
+        response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data=data,
+        )
+        self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert "Text is required" in response.json.get("message")
+
+    def test_create_comment_no_auth(self) -> None:
+        account, _ = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data = {"text": "No auth"}
+        response = self.make_unauthenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            data=data,
+        )
+        self.assert_error_response(
+            response,
+            401,
+            AccessTokenErrorCode.AUTHORIZATION_HEADER_NOT_FOUND,
+        )
+
+    def test_create_comment_invalid_token(self) -> None:
+        account, _ = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data = {"text": "Invalid token"}
+        response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            "invalid_token",
+            data=data,
+        )
+        self.assert_error_response(
+            response,
+            401,
+            AccessTokenErrorCode.ACCESS_TOKEN_INVALID,
+        )
+
+    def test_get_comments_empty(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        response = self.make_authenticated_comment_request(
+            "GET",
+            account.id,
+            task.id,
+            token,
+        )
+        assert response.status_code == 200
+        assert response.json is not None
+        assert response.json.get("items") == []
+        assert response.json.get("total_count") == 0
+
+    def test_get_comments_with_items(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data1 = {"text": "Comment 1"}
+        data2 = {"text": "Comment 2"}
+        self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data=data1,
+        )
+        self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data=data2,
+        )
+        response = self.make_authenticated_comment_request(
+            "GET",
+            account.id,
+            task.id,
+            token,
+        )
+        assert response.status_code == 200
+        assert response.json is not None
+        items = response.json.get("items")
+        assert len(items) == 2
+        texts = {item["text"] for item in items}
+        assert "Comment 1" in texts
+        assert "Comment 2" in texts
+        assert response.json.get("total_count") == 2
+
+    def test_get_single_comment_success(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        data = {"text": "Single comment"}
+        create_response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data=data,
+        )
+        comment_id = create_response.json.get("id")
+        response = self.make_authenticated_comment_request(
+            "GET",
+            account.id,
+            task.id,
+            token,
+            comment_id=comment_id,
+        )
+        assert response.status_code == 200
+        assert response.json is not None
+        assert response.json.get("id") == comment_id
+        assert response.json.get("text") == "Single comment"
+
+    def test_get_single_comment_not_found(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        response = self.make_authenticated_comment_request(
+            "GET",
+            account.id,
+            task.id,
+            token,
+            comment_id="nonexistent",
+        )
+        self.assert_error_response(response, 404, TaskErrorCode.NOT_FOUND)
+
+    def test_update_comment_success(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        create_response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data={"text": "Old text"},
+        )
+        comment_id = create_response.json.get("id")
+        update_response = self.make_authenticated_comment_request(
+            "PATCH",
+            account.id,
+            task.id,
+            token,
+            comment_id=comment_id,
+            data={"text": "Updated text"},
+        )
+        assert update_response.status_code == 200
+        assert update_response.json is not None
+        assert update_response.json.get("id") == comment_id
+        assert update_response.json.get("text") == "Updated text"
+
+    def test_update_comment_missing_text(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        create_response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data={"text": "Old text"},
+        )
+        comment_id = create_response.json.get("id")
+        response = self.make_authenticated_comment_request(
+            "PATCH",
+            account.id,
+            task.id,
+            token,
+            comment_id=comment_id,
+            data={},
+        )
+        self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert "Text is required" in response.json.get("message")
+
+    def test_update_comment_not_found(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        response = self.make_authenticated_comment_request(
+            "PATCH",
+            account.id,
+            task.id,
+            token,
+            comment_id="nonexistent",
+            data={"text": "Updated text"},
+        )
+        self.assert_error_response(response, 404, TaskErrorCode.NOT_FOUND)
+
+    def test_delete_comment_success(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        create_response = self.make_authenticated_comment_request(
+            "POST",
+            account.id,
+            task.id,
+            token,
+            data={"text": "To delete"},
+        )
+        comment_id = create_response.json.get("id")
+        delete_response = self.make_authenticated_comment_request(
+            "DELETE",
+            account.id,
+            task.id,
+            token,
+            comment_id=comment_id,
+        )
+        assert delete_response.status_code == 204
+        assert delete_response.data == b""
+        list_response = self.make_authenticated_comment_request(
+            "GET",
+            account.id,
+            task.id,
+            token,
+        )
+        assert list_response.status_code == 200
+        assert list_response.json.get("total_count") == 0
+
+    def test_delete_comment_not_found(self) -> None:
+        account, token = self.create_account_and_get_token()
+        task = self.create_test_task(account_id=account.id)
+        response = self.make_authenticated_comment_request(
+            "DELETE",
+            account.id,
+            task.id,
+            token,
+            comment_id="nonexistent",
+        )
+        self.assert_error_response(response, 404, TaskErrorCode.NOT_FOUND)
+
+    def test_comments_are_account_isolated_via_api(self) -> None:
+        account1, token1 = self.create_account_and_get_token(
+            "user1@example.com",
+            "password1",
+        )
+        account2, token2 = self.create_account_and_get_token(
+            "user2@example.com",
+            "password2",
+        )
+        task = self.create_test_task(account_id=account1.id)
+        create_response = self.make_authenticated_comment_request(
+            "POST",
+            account1.id,
+            task.id,
+            token1,
+            data={"text": "Account 1 comment"},
+        )
+        comment_id = create_response.json.get("id")
+        get_response = self.make_cross_account_comment_request(
+            "GET",
+            account1.id,
+            task.id,
+            token2,
+            comment_id=comment_id,
+        )
+        patch_response = self.make_cross_account_comment_request(
+            "PATCH",
+            account1.id,
+            task.id,
+            token2,
+            comment_id=comment_id,
+            data={"text": "Hacked"},
+        )
+        delete_response = self.make_cross_account_comment_request(
+            "DELETE",
+            account1.id,
+            task.id,
+            token2,
+            comment_id=comment_id,
+        )
+        self.assert_error_response(
+            get_response,
+            401,
+            AccessTokenErrorCode.UNAUTHORIZED_ACCESS,
+        )
+        self.assert_error_response(
+            patch_response,
+            401,
+            AccessTokenErrorCode.UNAUTHORIZED_ACCESS,
+        )
+        self.assert_error_response(
+            delete_response,
+            401,
+            AccessTokenErrorCode.UNAUTHORIZED_ACCESS,
+        )
+        verify_response = self.make_authenticated_comment_request(
+            "GET",
+            account1.id,
+            task.id,
+            token1,
+            comment_id=comment_id,
+        )
+        assert verify_response.status_code == 200
+        assert verify_response.json.get("id") == comment_id


### PR DESCRIPTION
****Task 1 – Comments API

------Approach
- Added `TaskCommentView` to handle CRUD for task comments.
- Endpoints:
  - POST /api/accounts/<account_id>/tasks/<task_id>/comments
  - GET /api/accounts/<account_id>/tasks/<task_id>/comments
  - GET /api/accounts/<account_id>/tasks/<task_id>/comments/<comment_id>
  - PATCH /api/accounts/<account_id>/tasks/<task_id>/comments/<comment_id>
  - DELETE /api/accounts/<account_id>/tasks/<task_id>/comments/<comment_id>
- Comments are stored as an embedded `comments` array on the task, each with:
  - `id`, `text`, `created_at`, `updated_at`.

------ Key decisions
- Reused existing patterns:
  - `TaskRepository.collection()` for DB access.
  - `TaskBadRequestError` / `TaskNotFoundError` for error handling.
  - `access_auth_middleware` to enforce authentication and account scoping.
- Used embedded comments instead of a separate collection to keep reads simple
  and aligned with the existing MongoDB task model.
- Validated:
  - Request body is required.
  - `text` is mandatory.
  - Task must exist, be active, and belong to the given account.

--------Tests
- Added / updated tests in `tests/modules/task/test_task_comment_api.py`.
- Covered:
  - Creating comments (success + validation errors + auth cases).
  - Listing comments (empty and non-empty).
  - Getting a single comment.
  - Updating a comment (success, missing text, not found).
  - Deleting a comment (success, not found).
  - Account isolation between different users.
- Command used:

  ```bash
  APP_ENV=testing PYTHONPATH=src/apps/backend python -m pytest tests/modules/task/test_task_comment_api.py

