### PR TITLE
fix: allow ACME challenge solver pods for SSL certificate generation

### DIFF
--- a/lib/kube/core/network-policy.yaml
+++ b/lib/kube/core/network-policy.yaml
@@ -60,6 +60,11 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+    
+    # Allow MongoDB database connections
+    - ports:
+        - protocol: TCP
+          port: 27017
 
 ---
 # Allow nginx ingress to reach our app


### PR DESCRIPTION
## Description
This PR fixes critical network policy issues that were preventing SSL/HTTPS connectivity and automatic SSL certificate provisioning in both preview and production environments. The changes enable external HTTPS API calls and ensure cert-manager can successfully complete ACME HTTP-01 challenges for SSL certificate issuance and renewal.
Video Walkthrough : https://www.loom.com/share/7a222d93d62343acaf212feb446cf47e
## Changes
 **Added HTTPS egress rule**: Added port 443/TCP egress policy to allow outbound SSL/HTTPS connections to external services
 **Added MongoDB egress rule**: Added port 27017/TCP egress policy for MongoDB database connectivity
 **Added ACME challenge network policy**: Created dedicated policy for cert-manager HTTP-01 challenge pods with:
  • Ingress on port 8089/TCP from default namespace (for Let's Encrypt validation)
  • DNS egress on port 53/UDP to kube-system namespace
  • Pod selector targeting acme.cert-manager.io/http01-solver=true labels
 **Fixed SSL certificate auto-renewal**: Ensures cert-manager can complete challenge validation without network policy blocking

## Tests
### Manual test cases run
- test 1 previews work after the fix
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/171ac3bd-1e36-454a-9f5f-9c5339fd0d91" />
