### PR TITLE
fix(ci): include network-policy.yaml in Checkov scan directory

### DIFF
--- a/lib/kube/preview/deployment.yaml
+++ b/lib/kube/preview/deployment.yaml
@@ -1,4 +1,3 @@
-# Preview environment deployment configuration
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:


### PR DESCRIPTION
## Description
This PR fixes the Checkov CI scan failing with `CKV2_K8S_6` (Minimize the admission of pods which lack an associated NetworkPolicy) on PRs that modify deployment files. The root cause is that the CI only copies changed files to the scan directory, so Checkov cannot see the NetworkPolicy defined in `lib/kube/core/network-policy.yaml` when only deployment files are modified.
Video Walkthrough: https://www.loom.com/share/27c7143807484fc7968076fcb5132dc3
## Changes
- Updated `.github/workflows/ci.yml` to copy `lib/kube/core/network-policy.yaml` to the scan directory when any `lib/kube/` files change
- This gives Checkov full context to detect that NetworkPolicy exists for the deployments

## Tests
### Manual test cases run
- Create a PR that only modifies `lib/kube/preview/deployment.yaml` and verify Checkov no longer fails with CKV2_K8S_6
Before:
<img width="1858" height="916" alt="image" src="https://github.com/user-attachments/assets/a672f2d3-b2e1-4be6-b665-f15ec34592be" />
After:
<img width="1886" height="962" alt="image" src="https://github.com/user-attachments/assets/59ad3c95-265f-449c-8a32-b7813400d57f" />
- Verify the network-policy.yaml file is correctly copied to `iac_changed_files/lib/kube/core/` during CI execution
<img width="1894" height="875" alt="image" src="https://github.com/user-attachments/assets/4b68b9f6-53ed-4a7d-9aba-557ca3ba532e" />

Closes #591