### PR TITLE
fix(deps): patch CVE-2026-25547 in @isaacs/brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2670,8 +2670,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -108,9 +108,10 @@
     "webpack-merge": "^5.8.0"
   },
   "overrides": {
+    "@isaacs/brace-expansion": "5.0.1",
+    "@remix-run/router": "1.23.2",
     "braces": "3.0.3",
     "minimist": "^1.2.8",
-    "nconf": "0.11.4",
-    "@remix-run/router": "1.23.2"
+    "nconf": "0.11.4"
   }
 }


### PR DESCRIPTION
## Description

Patches a HIGH severity vulnerability (CVE-2026-25547) in `@isaacs/brace-expansion` package which has an Uncontrolled Resource Consumption issue. The fix adds an npm override to force the package to version 5.0.1 which contains the security patch.
Video Walkthrough: https://www.loom.com/share/13e89e0f930f42b6998d56f30c6d53ee
## Changes

- Added `@isaacs/brace-expansion: 5.0.1` to npm overrides in `package.json`
- Updated `package-lock.json` to reflect the overridden version

## Tests
### Manual test cases run
Test 1: Before the package update
-  before this changes PRs created would fail the scan workflow as Trivy identified vulnerable packages 
<img width="1880" height="867" alt="image" src="https://github.com/user-attachments/assets/6a117e4f-338c-4e93-88d2-2825dee42972" />

Test 2: After the package update 
- After the package updates the Trivy scan workflow passes without breaking any funtionality 
<img width="1880" height="866" alt="image" src="https://github.com/user-attachments/assets/9ad1a2b2-8be0-4688-9d2a-c3e593e7f542" />