### PR TITLE
chore(k8s): add CronJob to clean up old ReplicaSets

### DIFF
--- a/lib/kube/core/cleanup-cronjob.yaml
+++ b/lib/kube/core/cleanup-cronjob.yaml
@@ -40,44 +40,32 @@ spec:
                 capabilities:
                   drop:
                     - ALL
+              # NOTE: This script avoids $VAR references for runtime variables
+              # because the deploy pipeline runs envsubst on all YAML files,
+              # which replaces undefined $VAR patterns with empty strings.
+              # Only $(subshell) syntax is safe from envsubst.
               command:
                 - /bin/bash
                 - -c
                 - |
                   set -e
 
-                  echo "Starting ReplicaSet cleanup for namespace: $NAMESPACE"
+                  echo "Starting ReplicaSet cleanup for namespace: $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+                  echo "Deleting ReplicaSets with 0 replicas older than 7 days"
 
-                  # Calculate cutoff timestamp (7 days ago in seconds since epoch)
-                  NOW=$(date +%s)
-                  SEVEN_DAYS_AGO=$((NOW - 604800))  # 7 days = 604800 seconds
+                  kubectl get replicaset \
+                    -n "$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)" \
+                    -o json | \
+                    jq -r '.items[]
+                      | select(.spec.replicas == 0 and .status.replicas == 0)
+                      | select((.metadata.creationTimestamp | fromdateiso8601) < (now - 604800))
+                      | .metadata.name' | \
+                    xargs -r -t -n1 \
+                      kubectl delete replicaset \
+                        --ignore-not-found=true \
+                        -n "$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
 
-                  echo "Deleting ReplicaSets older than 7 days (cutoff: $(date -u -d @$SEVEN_DAYS_AGO '+%Y-%m-%d %H:%M:%S'))"
-
-                  # Find and delete old replica sets
-                  DELETED=0
-                  while IFS= read -r rs_name rs_created; do
-                    if [ -n "$rs_name" ]; then
-                      # Convert ISO timestamp to epoch seconds for comparison
-                      rs_timestamp=$(date -d "$rs_created" +%s 2>/dev/null || echo "0")
-
-                      if [ "$rs_timestamp" -lt "$SEVEN_DAYS_AGO" ]; then
-                        echo "Deleting ReplicaSet: $rs_name (created: $rs_created)"
-                        kubectl delete replicaset "$rs_name" -n "$NAMESPACE" --ignore-not-found=true
-                        DELETED=$((DELETED + 1))
-                      fi
-                    fi
-                  done < <(kubectl get replicaset -n "$NAMESPACE" -o json | \
-                    jq -r '.items[] |
-                    select(.spec.replicas == 0 and .status.replicas == 0) |
-                    "\(.metadata.name) \(.metadata.creationTimestamp)"')
-
-                  echo "Cleanup complete. Deleted $DELETED old ReplicaSets."
-              env:
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
+                  echo "Cleanup complete."
               volumeMounts:
                 - name: sa-token
                   mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/lib/kube/core/network-policy.yaml
+++ b/lib/kube/core/network-policy.yaml
@@ -145,3 +145,31 @@ spec:
       ports:
         - protocol: UDP
           port: 53
+
+---
+# Allow cleanup CronJob to reach the Kubernetes API server
+# The cleanup pod needs to list and delete ReplicaSets via kubectl
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cleanup-egress
+  namespace: $KUBE_NS
+spec:
+  podSelector:
+    matchLabels:
+      app: replicaset-cleanup
+  policyTypes:
+    - Egress
+  egress:
+    # Allow DNS lookups (needed for kubernetes.default.svc resolution)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+    # Allow HTTPS to Kubernetes API server
+    - ports:
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
## Description

Adds a Kubernetes CronJob that automatically cleans up old ReplicaSets to prevent cluster clutter and reduce etcd storage overhead. Every deployment creates a new ReplicaSet; old ones persist at 0 replicas indefinitely, cluttering `kubectl` output and wasting resources.

Also adds a dedicated NetworkPolicy to allow the cleanup pod egress access to the Kubernetes API server and DNS, which is otherwise blocked by the default-deny-egress policy.

Video Walkthrough: https://www.loom.com/share/a2d1f57ca41849a5812a61b560318b54

Closes #603

Reference: [Foundation PR #114](https://github.com/jalantechnologies/foundation/pull/114)

## Changes

### CronJob (`lib/kube/core/cleanup-cronjob.yaml`)

- Daily CronJob (3 AM UTC) that safely deletes ReplicaSets meeting ALL criteria:
  - `spec.replicas == 0` (not supposed to have pods)
  - `status.replicas == 0` (no actual running pods)
  - Older than 7 days (preserves recent ones for rollback)
- Includes ServiceAccount, Role, and RoleBinding with least-privilege RBAC (get/list/delete ReplicaSets only)
- Security: non-root (UID 10001), read-only filesystem, all capabilities dropped, pinned image with SHA256 digest
- Resources: 10m/32Mi requests, 100m/128Mi limits
- Schedule: daily at 3 AM UTC, concurrency policy `Forbid`, TTL 24h
- Script uses `$(subshell)` syntax instead of `$VAR` references to avoid the deploy pipeline's `envsubst` from replacing runtime shell variables with empty strings
- Uses `jq` built-in `now` and `fromdateiso8601` for date filtering, eliminating the need for intermediate shell variables

### NetworkPolicy (`lib/kube/core/network-policy.yaml`)

- Added `allow-cleanup-egress` policy targeting pods with label `app: replicaset-cleanup`
- Grants DNS egress (UDP 53 to kube-system) for `kubernetes.default.svc` resolution
- Grants HTTPS egress (TCP 443) for Kubernetes API server access

## Tests

### Manual verification in preview environment

- Created manual job: `kubectl create job manual-cleanup-test --from=cronjob/replicaset-cleanup -n flask-react-app-preview`
- Job completed successfully — namespace resolved correctly, kubectl commands executed without timeout
- Logs confirmed working execution:
  ```
  Starting ReplicaSet cleanup for namespace: flask-react-app-preview
  Deleting ReplicaSets with 0 replicas older than 7 days
  Cleanup complete.
  ```
<img width="1643" height="307" alt="image" src="https://github.com/user-attachments/assets/6ac19d34-bf3d-4ed7-9a4f-14eb89f579cd" />
- Verified NetworkPolicy allows cleanup pod to reach the Kubernetes API server
<img width="1912" height="404" alt="image" src="https://github.com/user-attachments/assets/1318d068-db92-4a0c-b5bf-c9ff19634b54" />
- Verified `envsubst` does not mangle the inline script (all `$(subshell)` syntax preserved after deployment)
