### PR TITLE
fix(deps): upgrade axios to 1.13.5 to patch CVE-2026-25639

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@datadog/browser-rum": "^6.6.4",
         "@datadog/browser-rum-react": "^6.6.4",
         "autoprefixer": "^10.4.18",
-        "axios": "^1.0.0",
+        "axios": "^1.13.5",
         "clsx": "^2.1.0",
         "config": "^3.3.7",
         "cors": "^2.8.5",
@@ -4333,13 +4333,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@datadog/browser-rum": "^6.6.4",
     "@datadog/browser-rum-react": "^6.6.4",
     "autoprefixer": "^10.4.18",
-    "axios": "^1.0.0",
+    "axios": "^1.13.5",
     "clsx": "^2.1.0",
     "config": "^3.3.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Description
Upgrades axios dependency from version 1.13.2 to 1.13.5 to address CVE-2026-25639, a HIGH severity vulnerability that allows Denial of Service via proto key in mergeConfig.

This fix resolves the Trivy security scan failure in PRs created from main branch.

Video Walkthrough: https://www.loom.com/share/9286e3382cea4b959a5a7264a4be71db

## Changes
- Updated `package.json` to pin `axios` to `^1.13.5`
- Regenerated `package-lock.json` with updated dependencies

## Tests
### Manual test cases run
Test 1: Before the package update
- Before this change, PRs created would fail the scan workflow as Trivy identified the vulnerable axios package (CVE-2026-25639)
<img width="1889" height="975" alt="image" src="https://github.com/user-attachments/assets/c690906e-509e-48bd-aedf-41506b9ddae4" />

Test 2: After the package update
- After the package update, the Trivy scan workflow passes without breaking any functionality
<img width="1895" height="968" alt="image" src="https://github.com/user-attachments/assets/784ba0e3-aa09-4f20-9223-4728f025abd9" />