### PR TITLE
fix(kube): add node affinity to celery worker deployments

### DIFF
--- a/lib/kube/preview/worker-deployment.yaml
+++ b/lib/kube/preview/worker-deployment.yaml
@@ -26,6 +26,15 @@ spec:
         fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: doks.digitalocean.com/node-pool
+                    operator: In
+                    values:
+                      - platform-cluster-01-staging-pool
       imagePullSecrets:
         - name: regcred
       containers:

--- a/lib/kube/production/worker-deployment.yaml
+++ b/lib/kube/production/worker-deployment.yaml
@@ -26,6 +26,15 @@ spec:
         fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: doks.digitalocean.com/node-pool
+                    operator: In
+                    values:
+                      - platform-cluster-01-production-pool
       imagePullSecrets:
         - name: regcred
       containers:


### PR DESCRIPTION
# Pull Request

## Summary

Worker deployments (`lib/kube/production/worker-deployment.yaml` and `lib/kube/preview/worker-deployment.yaml`) were missing `nodeAffinity` configuration, whereas the main application deployments already had it set. Without this, worker pods could be scheduled on any node pool in the cluster — including nodes belonging to a different environment — causing resource contention and inconsistent scheduling behaviour.

This PR adds `affinity.nodeAffinity` to both worker deployments, targeting the same node pools as their respective main app deployments:
- Production worker → `platform-cluster-01-production-pool`
- Preview worker → `platform-cluster-01-staging-pool`

Closes #617

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context
Video Walkthrough: https://www.loom.com/share/6b53bbb5eed9462ca14c11c7802c9547
No code changes — infrastructure/Kubernetes manifests only. The node affinity added mirrors exactly what is already present in `lib/kube/production/deployment.yaml` and `lib/kube/preview/deployment.yaml`.
