### PR TITLE
fix: add Datadog config defaults and remove dead enabled flag

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,11 @@ mongodb:
 
 web_app_host: 'http://localhost:3000'
 
+datadog:
+  app_name: 'flask-react-app'
+  site_name: 'datadoghq.com'
+  log_level: 'info'
+
 logger:
   transports: ['console']
 
@@ -29,7 +34,5 @@ accounts:
 
 public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
-  datadog:
-    enabled: 'false'
 
 BOOTSTRAP_APP: false


### PR DESCRIPTION
## Problem

Any project scaffolded from this template that deploys to production **without** explicitly setting `DATADOG_APP_NAME`, `DATADOG_SITE_NAME`, or `DATADOG_LOG_LEVEL` will crash at startup with a `MissingKeyError`. The sequence is:

1. `production.yml` sets `logger.transports: ['console', 'datadog']`
2. `Loggers.initialize_loggers()` instantiates `DatadogLogger()`
3. `DatadogLogger.__init__` calls `LogLevel.get_level()`
4. `LogLevel.get_level()` calls `ConfigService.get_value(key="datadog.log_level")` — no default exists → **crash**
5. When a log is emitted, `DatadogHandler.emit()` reads `datadog.site_name` and `datadog.app_name` — same problem

A second, separate issue: `public.datadog.enabled: 'false'` exists in `default.yml` but is **never read** by any backend logger code (`loggers.py`, `datadog_logger.py`, `datadog_handler.py`). The actual gate that controls whether Datadog backend logging is active is `logger.transports`. A developer who sees `enabled: 'false'` in the default config may reasonably assume that flipping it to `'true'` (or setting `DATADOG_ENABLED`) activates backend Datadog logging — it does not. This creates false confidence and makes the config harder to reason about.

## Changes

- **`config/default.yml`**: Added safe defaults for `datadog.app_name`, `datadog.site_name`, and `datadog.log_level` so the app starts without error when the corresponding env vars are absent.
- **`config/default.yml`**: Removed `public.datadog.enabled: 'false'` — the flag is dead for backend logging. The env var `DATADOG_ENABLED` still maps through `custom-environment-variables.yml` for the frontend RUM SDK, and `production.yml` / `preview.yml` correctly set it to `'true'` for those environments.

## Test plan

- [ ] Boot the app locally without setting any `DATADOG_*` env vars — confirm no `MissingKeyError` on startup
- [ ] Verify `logger.transports: ['console']` (default) does not initialise `DatadogLogger`
- [ ] In a production-like config (`logger.transports: ['datadog']`), confirm the app starts and logs fall back to the default values
- [ ] Confirm frontend RUM SDK still initialises correctly in production/preview (controlled by `logger.transports` and `DATADOG_ENABLED` env var via `custom-environment-variables.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)