### PR TITLE
chore: add pytest_cache to prettierignore and improve CI coverage and SonarQube steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,10 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
         run: |
           PROJECT_KEY=$(grep 'sonar.projectKey' sonar-project.properties | cut -d'=' -f2 | tr -d ' ')
-          echo "Quality gate status:"
-          curl -sf -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}" | python3 -m json.tool || true
-          echo "New issues:"
-          curl -sf -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/issues/search?projectKeys=${PROJECT_KEY}&resolved=false&sinceLeakPeriod=true&ps=10" | python3 -m json.tool || true
+          echo "Quality gate status (PR-specific):"
+          curl -sf -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&pullRequest=${{ github.event.number }}" | python3 -m json.tool || true
+          echo "New issues on this PR:"
+          curl -sf -u "${SONAR_TOKEN}:" "${SONAR_HOST_URL}/api/issues/search?componentKeys=${PROJECT_KEY}&pullRequest=${{ github.event.number }}&resolved=false&ps=20" | python3 -c "import sys,json;d=json.load(sys.stdin);print('total:',d.get('total'));[print(i.get('rule'),i.get('severity'),i.get('status'),i.get('component'),'line:',i.get('line'),'|',i.get('message')) for i in d.get('issues',[])]" || true
 
       - name: Fail if SonarQube analysis failed
         if: steps.sonar_analysis.outcome == 'failure'
@@ -322,16 +322,21 @@ jobs:
         run: docker compose -f docker-compose.test.yml down -v || true
 
       - name: Fix coverage paths for SonarQube
+        if: always()
         run: |
-          sed -i 's|/app/||g' output/coverage.xml || true
+          if [ -f output/coverage.xml ]; then
+            sed -i 's|/app/||g' output/coverage.xml
+            echo "Coverage paths fixed for SonarQube"
+          fi
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        if: always()
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
           name: coverage-report
           path: output/coverage.xml
+          if-no-files-found: ignore
           retention-days: 1
-        continue-on-error: true
 
       - name: Coverage report
         continue-on-error: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
 /.venv
+**/.pytest_cache


### PR DESCRIPTION
Closes #641, closes #642

## Changes

### `.prettierignore`
- Add `**/.pytest_cache` to prevent `fmt:check:ts` matching files inside pytest cache directories (#641)

### `.github/workflows/ci.yml`
Three improvements (#642):

1. Add `if: always()` to the "Fix coverage paths for SonarQube" step so it runs even when tests fail, and guard with a file-existence check instead of `|| true`
2. Change "Upload coverage report" from `continue-on-error: true` to `if: always()` + `if-no-files-found: ignore` for more explicit behaviour; also pin to hash `6f51ac03`
3. Update SonarQube quality gate debug curl commands to include `&pullRequest=${{ github.event.number }}` so they show PR-specific analysis rather than overall project status