### PR TITLE
test: verify clean workflow fix

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@fad88356620fd16b87d7aef8fe909917eeaf7f19
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@rehan/fix/clean-workflow
     concurrency:
       group: ci-preview-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
Testing the clean workflow fix from jalantechnologies/github-ci#113

This PR references the `rehan/fix/clean-workflow` branch to test the `--wait=false` fix for PVC deletion hangs.

**To test:**
1. Close this PR
2. Verify the clean workflow completes quickly (seconds instead of 6-hour timeout)
3. Verify preview environment resources are properly cleaned up