### PR TITLE
fix: group coverage property under # Coverage section in sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,12 @@
 sonar.projectKey=jalantechnologies_flask-react-template
 sonar.projectVersion=1.0
-sonar.python.coverage.reportPaths=output/coverage.xml
 
 # Tests
 sonar.tests=tests/
 sonar.test.exclusions=tests/**/*
+
+# Coverage
+sonar.python.coverage.reportPaths=output/coverage.xml
 
 # Modules
 sonar.modules=backend,frontend


### PR DESCRIPTION
Fixes #647

## Summary

- Moves `sonar.python.coverage.reportPaths` from its loose position between `sonar.projectVersion` and `# Tests` to a dedicated `# Coverage` section placed after `# Tests`
- Brings `flask-react-template` in line with the structure already established in `operate-demo` (landed via operate-demo PR#42)

## Changes

`sonar-project.properties`:

**Before:**
```
sonar.projectVersion=1.0
sonar.python.coverage.reportPaths=output/coverage.xml

# Tests
sonar.tests=tests/
sonar.test.exclusions=tests/**/*

# Modules
...
```

**After:**
```
sonar.projectVersion=1.0

# Tests
sonar.tests=tests/
sonar.test.exclusions=tests/**/*

# Coverage
sonar.python.coverage.reportPaths=output/coverage.xml

# Modules
...
```

## Test plan

- [x] Verify SonarCloud analysis still runs and picks up the coverage report after this change
- [x] Confirm no other sonar properties are accidentally removed or reordered