### PR TITLE
ci: free disk space before Docker image scan to prevent Trivy out-of-space crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,14 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: checkov_result/results_github_failed_only.md
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift /usr/local/share/boost /usr/local/share/powershell
+          sudo apt-get clean
+          docker image prune -af
+          df -h
+
       - name: Build Docker image for scanning
         run: |
           docker build -t flask-react-app:${{ steps.extract_branch.outputs.branch_hash }} .


### PR DESCRIPTION
## Summary

- Ports the disk cleanup fix from `jalantechnologies/operate#135` to address the same vulnerability tracked in issue #664
- Adds a **Free disk space** step immediately before the Docker image build in the `scan` CI job, removing unused toolchains (dotnet, Android SDK, GHC, CodeQL, Swift, Boost, PowerShell) and pruning stale Docker images
- Reclaims ~15–20 GB on GitHub-hosted runners, preventing the intermittent `FATAL: write … no space left on device` crash that occurs when Trivy extracts image layers into `/tmp` on older runner images

**Root cause:** GitHub's runner pool is heterogeneous. Older runner images (e.g. `20260413.86.1`) ship with more pre-installed software, leaving less free disk. When Trivy caches are warm (~168 MB) combined with the Docker build, there isn't enough space for Trivy to extract layers — causing a fatal write error. The downstream "Fail job if Trivy found issues" step then exits 1 with a misleading "❌ Trivy found vulnerabilities" message even though no CVEs were found.

Closes #664

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

The removed directories are safe to delete — none are used anywhere in the CI workflow:

| Directory | Tool | Size reclaimed |
|---|---|---|
| `/usr/share/dotnet` | .NET runtime | ~7 GB |
| `/usr/local/lib/android` | Android SDK | ~5 GB |
| `/opt/ghc` | Haskell GHC | ~2 GB |
| `/opt/hostedtoolcache/CodeQL` | CodeQL | ~1 GB |
| `/usr/share/swift` | Swift toolchain | ~1 GB |
| `/usr/local/share/boost` | Boost C++ | ~0.5 GB |
| `/usr/local/share/powershell` | PowerShell | ~0.5 GB |

The `df -h` output in CI logs will confirm the reclaimed space after this step runs.

Identical fix already proven stable in `jalantechnologies/operate` since Apr 25, 2026 (commit `5a32e86`).