### PR TITLE
fix: prevent logger handler leak (idempotent mount + once-per-session test setup)

### DIFF
--- a/src/apps/backend/modules/logger/internal/base_logger.py
+++ b/src/apps/backend/modules/logger/internal/base_logger.py
@@ -1,7 +1,17 @@
+import logging
 from abc import ABC, abstractmethod
 
 
 class BaseLogger(ABC):
+    def _attach_handler(self, logger: logging.Logger, handler: logging.Handler) -> None:
+        # Python loggers are process-global singletons keyed by name, so any logger setup that runs more
+        # than once (for example once per test via mount_logger) would otherwise stack a duplicate handler
+        # each time and multiply every log line. Attaching a given handler type at most once makes setup
+        # idempotent by construction, so callers do not have to guard against repeated initialization.
+        if any(isinstance(existing, type(handler)) for existing in logger.handlers):
+            return
+        logger.addHandler(handler)
+
     @abstractmethod
     def critical(self, *, message: str) -> None: ...
 

--- a/src/apps/backend/modules/logger/internal/console_logger.py
+++ b/src/apps/backend/modules/logger/internal/console_logger.py
@@ -8,12 +8,11 @@ class ConsoleLogger(BaseLogger):
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
 
-        # Create a console handler and set the level to INFO
         console_handler = logging.StreamHandler()
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         console_handler.setFormatter(formatter)
 
-        self.logger.addHandler(console_handler)
+        self._attach_handler(self.logger, console_handler)
 
     def critical(self, *, message: str) -> None:
         self.logger.critical(msg=message)

--- a/src/apps/backend/modules/logger/internal/datadog_logger.py
+++ b/src/apps/backend/modules/logger/internal/datadog_logger.py
@@ -15,7 +15,7 @@ class DatadogLogger(BaseLogger):
         self.handler = DatadogHandler("flask")
         self.handler.setLevel(LogLevel.get_level())
         self.handler.setFormatter(self.formatter)
-        self.logger.addHandler(self.handler)
+        self._attach_handler(self.logger, self.handler)
 
     def critical(self, *, message: str) -> None:
         self.logger.critical(message)

--- a/src/apps/backend/modules/logger/internal/loggers.py
+++ b/src/apps/backend/modules/logger/internal/loggers.py
@@ -11,6 +11,8 @@ class Loggers:
 
     @staticmethod
     def initialize_loggers() -> None:
+        if Loggers._LOGGERS:
+            return
         logger_transports = ConfigService[list[str]].get_value(key="logger.transports")
         for logger_transport in logger_transports:
             if logger_transport == LoggerTransports.CONSOLE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+from modules.logger.logger_manager import LoggerManager
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mount_loggers() -> None:
+    # Logger mounting configures process-global state and is only meaningful once per process, exactly
+    # as it runs once at server boot. Doing it here, session-scoped, is the correct home for it. Running
+    # it in per-test setup stacked a duplicate handler for every test and multiplied log output.
+    LoggerManager.mount_logger()

--- a/tests/modules/account/base_test_account.py
+++ b/tests/modules/account/base_test_account.py
@@ -4,7 +4,6 @@ from typing import Callable
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.account.rest_api.account_rest_api_server import AccountRestApiServer
 from modules.authentication.internals.otp.store.otp_repository import OTPRepository
-from modules.logger.logger_manager import LoggerManager
 from modules.notification.internals.store.account_notification_preferences_repository import (
     AccountNotificationPreferencesRepository,
 )
@@ -13,7 +12,6 @@ from modules.notification.internals.store.account_notification_preferences_repos
 class BaseTestAccount(unittest.TestCase):
     def setup_method(self, method: Callable) -> None:
         print(f"Executing:: {method.__name__}")
-        LoggerManager.mount_logger()
         AccountRestApiServer.create()
 
     def teardown_method(self, method: Callable) -> None:

--- a/tests/modules/application/base_test_application.py
+++ b/tests/modules/application/base_test_application.py
@@ -1,13 +1,10 @@
 import unittest
 from typing import Callable
 
-from modules.logger.logger_manager import LoggerManager
-
 
 class BaseTestApplication(unittest.TestCase):
     def setup_method(self, method: Callable) -> None:
         print(f"Executing:: {method.__name__}")
-        LoggerManager.mount_logger()
 
     def teardown_method(self, method: Callable) -> None:
         print(f"Executed:: {method.__name__}")

--- a/tests/modules/task/base_test_task.py
+++ b/tests/modules/task/base_test_task.py
@@ -7,7 +7,6 @@ from server import app
 from modules.account.account_service import AccountService
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.account.types import Account, CreateAccountByUsernameAndPasswordParams
-from modules.logger.logger_manager import LoggerManager
 from modules.task.internal.store.task_repository import TaskRepository
 from modules.task.rest_api.task_rest_api_server import TaskRestApiServer
 from modules.task.task_service import TaskService
@@ -26,7 +25,6 @@ class BaseTestTask(unittest.TestCase):
     DEFAULT_LAST_NAME = "User"
 
     def setUp(self) -> None:
-        LoggerManager.mount_logger()
         TaskRestApiServer.create()
 
     def tearDown(self) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a logger handler leak in the template. Every time the loggers are mounted, a new handler was attached to the same Python logger. Python loggers are process-global singletons keyed by name, so the handlers stacked instead of replacing each other, and a single log line got printed once per attached handler.

This showed up most in the test suite. The base test classes called `mount_logger()` in their per-test setup, so initialization ran once per test against the same global logger. Handlers grew linearly with each test, so across N tests the total prints became `N * (N + 1) / 2`. A 100-test suite printed about 5,050 lines instead of 100, the handler objects were never released so memory grew, and CI logs bloated.

There were two root causes. This PR fixes both.

## Root cause 1: adding a handler was not idempotent

`ConsoleLogger` and `DatadogLogger` both called `addHandler` unconditionally, so re-running setup stacked duplicates. `Loggers.initialize_loggers` also kept appending to the module-level `_LOGGERS` list.

Fix: a shared `BaseLogger._attach_handler` helper that attaches a given handler type at most once, used by both loggers. It checks by handler type, so it stays correct even if something else attaches a different handler to the same logger. Plus an early return in `initialize_loggers` so instances do not accumulate. Any future logger type inherits this safe behavior.

## Root cause 2: the test setup mounted the logger once per test

Logger mounting configures process-global state and is only meaningful once per process, the same way it runs once at server boot. Running it in per-test `setUp` / `setup_method` is what triggered the stacking.

Fix: a session-scoped `autouse` fixture in `tests/conftest.py` mounts the logger once for the whole run, and the per-test `mount_logger()` calls are removed from the base test classes.

Fix 1 makes the operation correct in isolation. Fix 2 makes it run the right number of times. Together the leak cannot come back, whether through tests or any future caller.

This was found and fixed downstream in a repo created from this template. Raising it here so the template is fixed at the source.

Closes #670

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

`black` and `isort` (the repo's configured formatters, line length 120) pass on all changed files.
