### PR TITLE
feat(security): warn at startup when the MongoDB connection is not using TLS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,7 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 - Validate and sanitize all incoming data; prefer Pydantic models for request bodies and query params.
 - Use parameterized Mongo queries. Avoid building raw query strings with user input.
 - Keep secrets in environment variables or Doppler; never commit credentials.
+- Use TLS on the MongoDB connection outside local development. Startup warns when `MONGODB_URI` lacks TLS — see [MongoDB Security](docs/mongodb-security.md).
 
 ## Testing Requirements
 
@@ -287,5 +288,6 @@ Choose your type carefully — it determines the label and semver impact.
 - [Backend Architecture](docs/backend-architecture.md)
 - [Frontend Architecture](docs/frontend-architecture.md)
 - [Configuration Guide](docs/configuration.md)
+- [MongoDB Security](docs/mongodb-security.md)
 - [Testing Guide](docs/testing.md)
 - [Engineering Handbook](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md)

--- a/docs/mongodb-security.md
+++ b/docs/mongodb-security.md
@@ -1,0 +1,72 @@
+# MongoDB Security
+
+## Why TLS Matters
+
+MongoDB holds sensitive data: bcrypt-hashed credentials, account records, and application state. Without TLS, all traffic between the application and MongoDB travels in plaintext. Anyone on the same network segment — including other containers on a shared host, or an attacker who has achieved lateral movement — can read or modify that traffic. This is a requirement under SOC 2 CC6.7 and ISO 27001 A.10.1.
+
+## URI Patterns That Satisfy the TLS Check
+
+When a MongoDB connection is created outside development and testing, the app checks `MONGODB_URI` and logs a warning if TLS is absent. The following URI forms pass the check:
+
+**MongoDB Atlas (SRV scheme — TLS is always on):**
+
+```
+mongodb+srv://user:pass@cluster.mongodb.net/dbname
+```
+
+**Self-hosted with TLS explicitly enabled:**
+
+```
+mongodb://host:27017/dbname?tls=true&tlsCAFile=/etc/ssl/mongo-ca.pem
+```
+
+**Legacy SSL parameter (accepted by the check, but `tls=true` is preferred):**
+
+```
+mongodb://host:27017/dbname?ssl=true
+```
+
+## How the Warning Works
+
+`ApplicationRepositoryClient` validates the URI when it creates a MongoDB connection (in `modules/application/repository.py`, where `mongodb.uri` is read and the client is constructed). If the URI does not use the `mongodb+srv://` scheme and does not contain `tls=true` or `ssl=true` in the query string, a `WARN`-level log is emitted. This is intentionally non-fatal: TLS may be terminated at the network layer (e.g. a TLS-terminating proxy or service mesh) without appearing in the URI itself. The warning is the operator's cue to either add TLS parameters or confirm that the network layer provides equivalent protection.
+
+The check is skipped when `APP_ENV` is `development` or `testing`.
+
+## Encryption at Rest
+
+### MongoDB Atlas
+
+Encryption at rest is enabled by default on all Atlas tiers using AES-256. No operator action is required.
+
+### Self-Hosted MongoDB
+
+**Enterprise Edition:** Supports native encryption at rest via the WiredTiger storage engine. Enable it in `mongod.conf`:
+
+```yaml
+security:
+  enableEncryption: true
+  encryptionKeyFile: /etc/mongodb/encryption.key
+```
+
+**Community Edition:** Does not support WiredTiger encryption. Rely on volume-level encryption instead:
+
+- **AWS:** encrypted EBS volumes (enable at volume creation or via the AWS console)
+- **Linux (bare metal / VMs):** LUKS full-disk or volume encryption
+- **Windows:** BitLocker
+
+### Responsibility Boundary
+
+The application configures the connection URI and warns about TLS at startup. Encryption at rest is the infrastructure / platform team's responsibility and cannot be enforced at the application layer.
+
+## Self-Hosted Production Checklist
+
+- TLS certificate issued for the MongoDB hostname (from a trusted CA or internal PKI)
+- `net.tls.mode: requireTLS` set in `mongod.conf` to reject plaintext connections
+- CA certificate available to the application container (`tlsCAFile` in the URI, or system trust store)
+- Volume-level encryption enabled, or WiredTiger encryption configured (Enterprise)
+- MongoDB user has least-privilege roles — avoid using the `root` user in production
+- `authSource` in the URI matches the database where the user was created (typically `admin` for root-style init)
+
+## Dev Environment
+
+The dev `docker-compose.dev.yml` runs an unauthenticated MongoDB on the local network and points the app at `mongodb://app-db:27017/flask-react-template-dev` via `MONGODB_URI`. This is intentional for local development only and must never be used in production: bind production Mongo to a private network, require authentication, and enable TLS. The TLS warning is suppressed for `APP_ENV=development`.

--- a/src/apps/backend/modules/application/repository.py
+++ b/src/apps/backend/modules/application/repository.py
@@ -1,5 +1,7 @@
+import os
+import urllib.parse
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import ClassVar, Optional
 
 from pymongo import MongoClient
 from pymongo.collection import Collection
@@ -11,6 +13,10 @@ from modules.logger.logger import Logger
 
 class ApplicationRepositoryClient:
     _client: Optional[MongoClient] = None
+
+    # TLS on the MongoDB connection is only enforced outside local development and the test suite,
+    # where plaintext traffic to a loopback Mongo is expected.
+    NON_TLS_EXEMPT_ENVS: ClassVar[frozenset[str]] = frozenset({"development", "testing"})
 
     @classmethod
     def get_client(cls) -> MongoClient:
@@ -25,14 +31,43 @@ class ApplicationRepositoryClient:
         else:
             return cls._create_client()
 
-    @staticmethod
-    def _create_client() -> MongoClient:
+    @classmethod
+    def _create_client(cls) -> MongoClient:
         connection_uri = ConfigService[str].get_value(key="mongodb.uri")
+        cls._warn_if_uri_lacks_tls(connection_uri)
         Logger.info(message=f"connecting to database - {connection_uri}")
         client = MongoClient(connection_uri, server_api=ServerApi("1"))
         Logger.info(message=f"connected to database - {connection_uri}")
 
         return client
+
+    @classmethod
+    def _warn_if_uri_lacks_tls(cls, connection_uri: str) -> None:
+        # Plaintext Mongo traffic exposes credentials and data in transit to anyone on the network
+        # segment (SOC 2 CC6.7, ISO 27001 A.10.1). Warn — non-fatal — when the URI does not opt into
+        # TLS, since TLS may instead be terminated at the network layer (proxy, service mesh) without
+        # appearing in the URI. See docs/mongodb-security.md.
+        app_env = os.environ.get("APP_ENV", "development")
+        if app_env in cls.NON_TLS_EXEMPT_ENVS:
+            return
+
+        parsed = urllib.parse.urlsplit(connection_uri)
+        query_params = urllib.parse.parse_qs(parsed.query)
+
+        has_tls = (
+            parsed.scheme == "mongodb+srv"
+            or query_params.get("tls", [""])[0].lower() == "true"
+            or query_params.get("ssl", [""])[0].lower() == "true"
+        )
+
+        if not has_tls:
+            Logger.warn(
+                message=(
+                    "MONGODB_URI does not appear to use TLS. In production this exposes data in transit. "
+                    "Use mongodb+srv:// (e.g. MongoDB Atlas) or append ?tls=true&tlsCAFile=/path/to/ca.pem "
+                    "to a mongodb:// URI. See docs/mongodb-security.md for guidance."
+                )
+            )
 
 
 class ApplicationRepository(ABC):


### PR DESCRIPTION
## What this changes

When the app connects to MongoDB, it now checks whether the connection is encrypted (TLS). If it is not — and we are not running locally or in tests — it logs a warning. The warning points to a new doc explaining how to fix it. Nothing is blocked; the app still starts.

It also adds `docs/mongodb-security.md` describing how to connect to MongoDB securely.

## The problem

Traffic between the app and MongoDB can travel either encrypted or in plaintext, depending on how the connection string (`MONGODB_URI`) is written. If TLS is off, everything sent to the database — including login credentials and user data — goes over the network in the clear.

Today nothing tells us when that happens. A production deployment can be running on a plaintext MongoDB connection and look completely healthy. The misconfiguration is invisible until someone audits it (or until it is exploited).

## Why it matters

Anyone who can see that network traffic — another container on the same host, or an attacker who has gotten a foothold inside the network — can read or tamper with the data in transit. Requiring encryption in transit is also a baseline control for SOC 2 and ISO 27001, which we will be expected to meet.

The goal here is simple: make a missing-TLS misconfiguration loud instead of silent, so it gets caught at deploy time rather than in an audit or an incident.

## How it works

- The check lives in `modules/application/repository.py`, on `ApplicationRepositoryClient` — the class that reads `MONGODB_URI` and opens the MongoDB connection. It runs at the moment a connection is created, so it sits with the code that actually owns the connection string.
- A connection is considered TLS-enabled if the URI either uses the `mongodb+srv://` scheme (MongoDB Atlas, where TLS is always on) or includes `tls=true` / `ssl=true`. Otherwise we log a warning.
- The warning is **not fatal**: TLS can also be enforced one layer down (a proxy or service mesh terminating TLS) without showing up in the URI, so blocking would produce false alarms. A warning is the right signal — it tells the operator to either turn on TLS in the URI or confirm the network layer already handles it.
- The check is **skipped for local development and the test suite** (`APP_ENV` of `development` or `testing`), where Mongo runs on localhost and plaintext is expected.

## How to verify

- Run the app with a plain `mongodb://...` URI and a non-dev `APP_ENV` → you see the TLS warning in the logs.
- Use a `mongodb+srv://...` URI, or add `?tls=true` → no warning.
- Run locally (default `APP_ENV=development`) → no warning, regardless of URI.

## Notes for the reviewer

- This is ported from our `operate` repo, where the same check has been running. There it lived on the bootstrap/seeding script; here it is moved onto the repository client, which is the more natural home in this codebase (our bootstrap script is a narrow, optional seeding task, not the place for a connection-security rule).
- No unit test is added. Our `CLAUDE.md` asks for end-to-end request tests and discourages isolated unit tests for internal helpers, and this check has no HTTP entry point. The detection logic was verified by hand against a range of URIs.

## Pre-Merge Checklist

- [ ] Tests pass
- [x] Self-reviewed
- [ ] AI code review completed (if applicable)