### PR TITLE
ci: allow build and revert conventional-commit types in pr-labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -31,14 +31,16 @@ jobs:
               { pattern: /^refactor(\(.+?\))?:/i, typeLabel: 'type: refactor', semverLabel: null },
               { pattern: /^test(\(.+?\))?:/i, typeLabel: 'type: test', semverLabel: null },
               { pattern: /^chore(\(.+?\))?:/i, typeLabel: 'type: chore', semverLabel: null },
+              { pattern: /^build(\(.+?\))?:/i, typeLabel: 'type: build', semverLabel: null },
               { pattern: /^ci(\(.+?\))?:/i, typeLabel: 'type: ci', semverLabel: null },
+              { pattern: /^revert(\(.+?\))?:/i, typeLabel: 'type: revert', semverLabel: null },
             ];
 
             // Find matching prefix
             const match = labelMappings.find(mapping => mapping.pattern.test(title));
 
             if (!match) {
-              core.setFailed(`❌ PR title does not follow conventional commit format. Expected format: type(scope): description\nValid types: feat, fix, perf, docs, style, refactor, test, chore, ci\nExample: feat(api): add new endpoint`);
+              core.setFailed(`❌ PR title does not follow conventional commit format. Expected format: type(scope): description\nValid types: feat, fix, perf, docs, style, refactor, test, chore, build, ci, revert\nExample: feat(api): add new endpoint`);
               return;
             }
 
@@ -57,7 +59,7 @@ jobs:
             const existingLabelNames = existingLabels.map(label => label.name);
 
             // Remove old type and semver labels if they differ
-            const typeLabels = ['type: feat', 'type: fix', 'type: perf', 'type: docs', 'type: style', 'type: refactor', 'type: test', 'type: chore', 'type: ci'];
+            const typeLabels = ['type: feat', 'type: fix', 'type: perf', 'type: docs', 'type: style', 'type: refactor', 'type: test', 'type: chore', 'type: build', 'type: ci', 'type: revert'];
             const semverLabels = ['semver: major', 'semver: minor', 'semver: patch'];
 
             for (const label of existingLabelNames) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,9 @@ PRs are automatically labeled based on title prefix via the `pr-labeler` workflo
 | `refactor:`                  | `type: refactor`           | —               |
 | `test:`                      | `type: test`               | —               |
 | `chore:`                     | `type: chore`              | —               |
+| `build:`                     | `type: build`              | —               |
 | `ci:`                        | `type: ci`                 | —               |
+| `revert:`                    | `type: revert`             | —               |
 | Breaking (`feat!:`, `fix!:`) | `type: feat` / `type: fix` | `semver: major` |
 
 Choose your type carefully — it determines the label and semver impact.


### PR DESCRIPTION
## Summary

The `pr-labeler` workflow runs a required check that validates the PR title against a list of conventional-commit types. That list is missing **`build`** and **`revert`** — both standard conventional-commit types. As a result, any PR titled `build: ...` or `revert: ...` fails the check.

This bites us on **every Dependabot PR**: Dependabot titles dependency bumps `build(deps): ...`, so the grouped GitHub Actions update (#678) currently fails its `label` check with:

```
❌ PR title does not follow conventional commit format.
Valid types: feat, fix, perf, docs, style, refactor, test, chore, ci
```

## Changes

- `.github/workflows/pr-labeler.yml`:
  - Add `build` and `revert` patterns to the label map → `type: build` / `type: revert`, no semver bump (consistent with `docs`/`chore`/`ci`).
  - Add them to the valid-types error message and to the type-label cleanup list.
- `AGENTS.md`: add the `build:` and `revert:` rows to the auto-labeling table so the docs match the workflow.

The `type: build` and `type: revert` labels don't need to be pre-created — the labeler's `addLabels` call creates missing labels on first use.

## Why these two

`build` and `revert` are part of the conventional-commit spec and are already listed as valid commit types in `AGENTS.md`'s commit-message section. The labeler's type list had simply drifted out of sync with that. This brings them back in line and unblocks Dependabot PRs.

## Pre-Merge Checklist

- [ ] Tests pass
- [x] Self-reviewed
- [ ] AI code review completed (if applicable)