### PR TITLE
chore: add MIT license with Better attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jalan Technology Consulting Pvt. Ltd. (Better, https://bettrhq.com/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ This project has three deployment environments that everyone can access:
 Once you have familiarized yourself with the documentation, head over to the [Engineering Handbook](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md) to learn about the best practices we follow at Better Software.
 
 PS: Before you start working on the application, these [three git settings](https://spin.atomicobject.com/git-configurations-default/) are a must-have!
+
+## License
+
+This project is licensed under the [MIT License](LICENSE). You are free to fork, modify, and use it, including commercially.
+
+It is built and maintained by **Better** ([Jalan Technology Consulting Pvt. Ltd.](https://bettrhq.com/)). The MIT license requires that the copyright and permission notice be retained in all copies. If you build on this template, we ask that you keep that attribution and, where practical, credit Better with a link back to [bettrhq.com](https://bettrhq.com/).


### PR DESCRIPTION
# Pull Request

## Summary

The repository declared `"license": "MIT"` in `package.json` but shipped no `LICENSE` file, so the stated license had no actual terms behind it. This adds the license text and makes the attribution explicit.

This is a public template that we want people to be able to fork and use, including commercially. The intent is openness with credit: keep it permissive, but make sure the work traces back to Better. The MIT license already requires the copyright and permission notice to be retained in every copy, so naming the maintaining entity in that notice gives us attribution without restricting use.

- Adds a `LICENSE` file with the MIT terms and a copyright line naming the maintaining entity: Jalan Technology Consulting Pvt. Ltd. (Better, https://bettrhq.com/).
- Adds a `License` section to the README stating the MIT terms and asking forks to retain the attribution and link back to bettrhq.com.

`package.json` already declared MIT, so no code or build change is involved. The template name (`flask-react-template`) and all infrastructure identifiers are unchanged.

---

## Pre-Merge Checklist

- [ ] Tests pass
- [ ] Self-reviewed
- [ ] AI code review completed (if applicable)

---

## Additional Context

Broader Better branding (page title, logo, in-app brand, package metadata) is intentionally kept out of this PR and will land separately, so the licensing change stays reviewable on its own.