### PR TITLE
fix(frontend): re-render router on login/logout so the view follows auth

### DIFF
--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -1,4 +1,11 @@
-import React, { createContext, PropsWithChildren, useContext } from 'react';
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 import useAsync from 'frontend/contexts/async.hook';
 import { AuthService } from 'frontend/services';
@@ -70,7 +77,7 @@ const loginFn = async (
 
 const logoutFn = (): void => removeAccessTokenFromStorage();
 
-const isUserAuthenticated = () => !!getAccessTokenFromStorage();
+const isTokenInStorage = (): boolean => !!getAccessTokenFromStorage();
 
 const sendOTPFn = async (
   phoneNumber: PhoneNumber,
@@ -88,6 +95,13 @@ const verifyOTPFn = async (
 };
 
 export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  // Authentication is React state, not a bare storage read, so the router and
+  // any consumer re-render the moment a session begins or ends. It is seeded
+  // from storage on mount to keep an existing session across reloads.
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
+    isTokenInStorage,
+  );
+
   const {
     asyncCallback: signup,
     error: signupError,
@@ -98,7 +112,7 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
     isLoading: isLoginLoading,
     error: loginError,
     result: loginResult,
-    asyncCallback: login,
+    asyncCallback: loginCallback,
   } = useAsync(loginFn);
 
   const {
@@ -111,31 +125,83 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
     isLoading: isVerifyOTPLoading,
     error: verifyOTPError,
     result: verifyOTPResult,
-    asyncCallback: verifyOTP,
+    asyncCallback: verifyOTPCallback,
   } = useAsync(verifyOTPFn);
 
+  // loginFn / verifyOTPFn persist the token; flip the reactive flag once the
+  // token is in storage so protected routes become reachable immediately.
+  const login = useCallback(
+    async (username: string, password: string) => {
+      const result = await loginCallback(username, password);
+      if (result) {
+        setIsAuthenticated(true);
+      }
+      return result;
+    },
+    [loginCallback],
+  );
+
+  const verifyOTP = useCallback(
+    async (phoneNumber: PhoneNumber, otp: string) => {
+      const result = await verifyOTPCallback(phoneNumber, otp);
+      if (result) {
+        setIsAuthenticated(true);
+      }
+      return result;
+    },
+    [verifyOTPCallback],
+  );
+
+  const logout = useCallback(() => {
+    logoutFn();
+    setIsAuthenticated(false);
+  }, []);
+
+  const isUserAuthenticated = useCallback(
+    () => isAuthenticated,
+    [isAuthenticated],
+  );
+
+  const value = useMemo(
+    () => ({
+      isLoginLoading,
+      isSendOTPLoading,
+      isSignupLoading,
+      isUserAuthenticated,
+      isVerifyOTPLoading,
+      login,
+      loginError,
+      loginResult,
+      logout,
+      sendOTP,
+      sendOTPError,
+      signup,
+      signupError,
+      verifyOTP,
+      verifyOTPError,
+      verifyOTPResult,
+    }),
+    [
+      isLoginLoading,
+      isSendOTPLoading,
+      isSignupLoading,
+      isUserAuthenticated,
+      isVerifyOTPLoading,
+      login,
+      loginError,
+      loginResult,
+      logout,
+      sendOTP,
+      sendOTPError,
+      signup,
+      signupError,
+      verifyOTP,
+      verifyOTPError,
+      verifyOTPResult,
+    ],
+  );
+
   return (
-    <AuthContext.Provider
-      value={{
-        isLoginLoading,
-        isSendOTPLoading,
-        isSignupLoading,
-        isUserAuthenticated,
-        isVerifyOTPLoading,
-        login,
-        loginError,
-        loginResult,
-        logout: logoutFn,
-        sendOTP,
-        sendOTPError,
-        signup,
-        signupError,
-        verifyOTP,
-        verifyOTPError,
-        verifyOTPResult,
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
   );
 };

--- a/src/apps/frontend/contexts/auth.provider.tsx
+++ b/src/apps/frontend/contexts/auth.provider.tsx
@@ -98,9 +98,8 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
   // Authentication is React state, not a bare storage read, so the router and
   // any consumer re-render the moment a session begins or ends. It is seeded
   // from storage on mount to keep an existing session across reloads.
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-    isTokenInStorage,
-  );
+  const [isAuthenticated, setIsAuthenticated] =
+    useState<boolean>(isTokenInStorage);
 
   const {
     asyncCallback: signup,
@@ -201,7 +200,5 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
     ],
   );
 
-  return (
-    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
-  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/apps/frontend/routes/index.tsx
+++ b/src/apps/frontend/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from '@datadog/browser-rum-react/react-router-v6';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
 import { useAuthContext } from 'frontend/contexts';
@@ -8,10 +8,15 @@ import { publicRoutes } from 'frontend/routes/public';
 
 export const AppRoutes = () => {
   const { isUserAuthenticated } = useAuthContext();
+  const authenticated = isUserAuthenticated();
 
-  const routes = isUserAuthenticated() ? protectedRoutes : publicRoutes;
-
-  const router = createBrowserRouter(routes);
+  // Rebuild the router whenever authentication flips, so logging in or out
+  // swaps the route set (and the current view) immediately instead of leaving
+  // the URL and the rendered page out of sync.
+  const router = useMemo(
+    () => createBrowserRouter(authenticated ? protectedRoutes : publicRoutes),
+    [authenticated],
+  );
 
   return <RouterProvider router={router} />;
 };


### PR DESCRIPTION
# Pull Request

## Summary

Logging out changed the URL to `/login` but left the user on the protected view, and the post-login landing could fall through to a not-found page. The cause is that authentication was a bare `localStorage` read and the router was built once at mount from that read. Mutating storage on login/logout triggered no re-render, so the route set never swapped and the URL and the rendered page drifted out of sync.

This makes authentication reactive:

- `AuthProvider` holds `isAuthenticated` as React state, seeded from storage on mount (so an existing session survives a reload) and flipped by `login` / `verifyOTP` (true) and `logout` (false).
- `AppRoutes` memoizes the router on that flag, so the public/protected route set and the rendered view swap the moment the session begins or ends.

The result: logout immediately shows the login screen, and a fresh login lands on the app. Token persistence, services, and the existing page flows are unchanged.

---

## Pre-Merge Checklist

- [ ] Tests pass
- [ ] Self-reviewed
- [ ] AI code review completed (if applicable)

---

## Additional Context

This is a pre-existing routing issue on `main`, independent of the in-flight design-system work. It surfaced once pages render reliably in local dev.