### PR TITLE
feat(frontend): inject public config into the bundle at build time

### DIFF
--- a/src/apps/frontend/index.html
+++ b/src/apps/frontend/index.html
@@ -5,7 +5,6 @@
   <meta charset='utf-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <title>Jalan Technologies | FLASK-REACT-TEMPLATE</title>
-  <script src='/config.js'></script>
 </head>
 <body>
 <div id='app'></div>

--- a/src/apps/frontend/webpack.base.js
+++ b/src/apps/frontend/webpack.base.js
@@ -1,7 +1,18 @@
 const path = require('path');
 
+const config = require('config');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const webpack = require('webpack');
+
+// The frontend's public config is injected into the bundle at build time as
+// `window.Config`, read from the `public` section of the active config
+// environment (config/*.yml) — the same values the backend exposes. This
+// removes the runtime `/config.js` fetch, so the app needs no extra request
+// (or dev-server proxy) to read its config.
+const publicConfig = JSON.stringify(
+  config.has('public') ? config.util.toObject(config.get('public')) : {},
+);
 
 module.exports = {
   target: 'web',
@@ -15,6 +26,9 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'style.css',
       chunkFilename: 'style.css',
+    }),
+    new webpack.DefinePlugin({
+      'window.Config': publicConfig,
     }),
   ],
   output: {


### PR DESCRIPTION
# Pull Request

## Summary

In local development the app rendered a blank page because `window.Config` was never set. The frontend loaded its config at runtime via a `<script src='/config.js'>` tag served by the backend, but the webpack dev server proxied only `/api` and `/assets`. A request to `localhost:3000/config.js` was served the SPA `index.html` instead, so `window.Config` stayed undefined, no auth route registered, and the page rendered nothing.

Rather than proxy one more path, this removes the runtime fetch entirely. The public config (the `public` section of the active `config/*.yml`, the same values the backend exposes) is injected into the JS bundle at build time via webpack `DefinePlugin`, and the `config.js` script tag is dropped from `index.html`. The app reads its config straight from the bundle, so no extra request and no dev-server proxy are needed.

This matches how the downstream Operate fork (derived from this template) already builds its config, and removes a dev/prod discrepancy.

Public config is client-facing by design; build-time injection exposes the same already-public values the runtime `config.js` did, so there is no new secret exposure.

---

## Pre-Merge Checklist

- [ ] Tests pass
- [ ] Self-reviewed
- [ ] AI code review completed (if applicable)

---

## Additional Context

Supersedes the dev-proxy approach in #685 (closed in favor of this). The backend `/config.js` route still exists but is no longer used by the frontend; leaving it is harmless and out of scope here.