### PR TITLE
chore: migrate platform hostnames from bettrhq.com to btr.group

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           app_name: flask-react-app
           app_env: preview
-          app_hostname: '{1}.preview.platform.bettrhq.com'
+          app_hostname: '{1}.preview.platform.btr.group'
           branch: pr-${{ github.event.pull_request.number }}
           deploy_id: ${{ github.run_number }}
           deploy_root: app/lib/kube

--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           app_name: flask-react-app
           app_env: preview
-          app_hostname: preview.flask-react-template.platform.bettrhq.com
+          app_hostname: preview.flask-react-template.platform.btr.group
           branch: main
           deploy_id: ${{ github.run_number }}
           deploy_root: app/lib/kube

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           app_name: flask-react-app
           app_env: production
-          app_hostname: flask-react-template.platform.bettrhq.com
+          app_hostname: flask-react-template.platform.btr.group
           branch: main
           deploy_id: ${{ github.run_number }}
           deploy_root: app/lib/kube

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ This project has three deployment environments that everyone can access:
 
 - **Production**
   - The live app for end users.
-  - Web App URL: [https://flask-react-template.platform.bettrhq.com](https://flask-react-template.platform.bettrhq.com)
+  - Web App URL: [https://flask-react-template.platform.btr.group](https://flask-react-template.platform.btr.group)
 
 - **Preview (per PR)**
   - A temporary environment for testing the latest changes in each PR
-  - A unique URL is generated for every pull request (e.g. `https://<github_sha>.preview.platform.bettrhq.com`).
+  - A unique URL is generated for every pull request (e.g. `https://<github_sha>.preview.platform.btr.group`).
 
 - **Permanent Preview**
   - Always reflects the latest `main` branch.
   - Useful for ongoing testing of the integrated codebase.
-  - URL: [https://preview.flask-react-template.platform.bettrhq.com](https://preview.flask-react-template.platform.bettrhq.com)
+  - URL: [https://preview.flask-react-template.platform.btr.group](https://preview.flask-react-template.platform.btr.group)
 
 ## Documentation Directory
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -180,7 +180,7 @@ All jobs run in parallel and independently:
 
 Single job that builds Docker image and deploys:
 
-1. **cd/deploy** (~3-4 min) - Builds Docker image and deploys to `{pr-name}.preview.platform.bettrhq.com`
+1. **cd/deploy** (~3-4 min) - Builds Docker image and deploys to `{pr-name}.preview.platform.btr.group`
 
 **Note:** All CI checks are advisory and run independently. CD deploys regardless of CI status to enable fast iteration. Code merged to `main` should have passing CI checks from the PR.
 

--- a/docs/infrastructure-overview.md
+++ b/docs/infrastructure-overview.md
@@ -28,11 +28,11 @@ For a full walkthrough, watch the video below.
 
 The template ships with three environments out of the box:
 
-| Environment           | Trigger                        | URL Pattern                                 |
-| --------------------- | ------------------------------ | ------------------------------------------- |
-| **Preview (per PR)**  | Every pull request open/update | `<github_sha>.preview.platform.bettrhq.com` |
-| **Permanent Preview** | Every merge to `main`          | `preview.<app>.<domain>`                    |
-| **Production**        | Manual or on merge to `main`   | `<app>.<domain>`                            |
+| Environment           | Trigger                        | URL Pattern                               |
+| --------------------- | ------------------------------ | ----------------------------------------- |
+| **Preview (per PR)**  | Every pull request open/update | `<github_sha>.preview.platform.btr.group` |
+| **Permanent Preview** | Every merge to `main`          | `preview.<app>.<domain>`                  |
+| **Production**        | Manual or on merge to `main`   | `<app>.<domain>`                          |
 
 Each preview environment is **fully isolated** — its own WebApp pod, Worker pod, and Redis pod — and is torn down automatically when the PR is closed.
 


### PR DESCRIPTION
# Pull Request

## Summary

Migrates the platform app hostnames from `platform.bettrhq.com` to `platform.btr.group` as part of moving our primary domain to **btr.group**.

Changes (clean switch — old hosts stop serving once redeployed):
- `app_hostname` in `production.yml`, `permanent_preview.yml`, `cd.yml`
- Environment URLs in `README.md`, `docs/deployment.md`, `docs/infrastructure-overview.md`

Out of scope (intentionally left unchanged):
- SonarQube coverage badge (`sonarqube.platform.bettrhq.com`) — separate droplet, deferred.
- Company website attribution link (`bettrhq.com` apex) — marketing site, not yet live on btr.group.

> ⚠️ **Do not merge until the `btr.group` DNS records are live**, pointing at the platform ingress LB `138.197.225.246`:
> `flask-react-template.platform`, `workers-dashboard.flask-react-template.platform`, `preview.flask-react-template.platform`, `preview.workers-dashboard.flask-react-template.platform`, `*.preview.platform`, `*.workers-dashboard.preview.platform`.
> Merging to `main` redeploys production + permanent preview onto the new hosts; cert-manager (HTTP-01) needs DNS live first or TLS will fail until propagation. The per-PR preview for this PR also deploys on `*.preview.platform.btr.group`.

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)
- [x] btr.group DNS records created and verified resolving to `138.197.225.246`

## Additional Context

Config/docs-only change. `remark` markdown lint and YAML parse both pass locally. No application code touched.