### PR TITLE
fix: require authentication and ownership for account profile updates (closes #695)

### DIFF
--- a/src/apps/backend/modules/account/rest_api/account_view.py
+++ b/src/apps/backend/modules/account/rest_api/account_view.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from typing import Any
 
 from flask import jsonify, request
 from flask.typing import ResponseReturnValue
@@ -15,12 +16,19 @@ from modules.account.types import (
     ResetPasswordParams,
     UpdateAccountProfileParams,
 )
-from modules.authentication.rest_api.access_auth_middleware import access_auth_middleware
+from modules.authentication.rest_api.access_auth_middleware import access_auth_middleware, enforce_account_ownership
 from modules.notification.errors import AccountNotificationPreferencesNotFoundError
 from modules.notification.types import CreateOrUpdateAccountNotificationPreferencesParams
 
 
 class AccountView(MethodView):
+    @staticmethod
+    def _get_request_body_as_object() -> dict[str, Any]:
+        request_data = request.get_json()
+        if not isinstance(request_data, dict):
+            raise AccountBadRequestError("Request body must be a JSON object")
+        return request_data
+
     def post(self) -> ResponseReturnValue:
         request_data = request.get_json()
         account_params: CreateAccountParams
@@ -55,13 +63,16 @@ class AccountView(MethodView):
         return jsonify(account_dict), 200
 
     def patch(self, account_id: str) -> ResponseReturnValue:
-        request_data = request.get_json()
+        request_data = self._get_request_body_as_object()
 
         if "token" in request_data and "new_password" in request_data:
-            reset_account_params = ResetPasswordParams(account_id=account_id, **request_data)
+            reset_account_params = ResetPasswordParams(
+                account_id=account_id, new_password=request_data["new_password"], token=request_data["token"]
+            )
             account = AccountService.reset_account_password(params=reset_account_params)
 
         elif "first_name" in request_data or "last_name" in request_data:
+            enforce_account_ownership(account_id)
             update_profile_params = UpdateAccountProfileParams(
                 first_name=request_data.get("first_name"), last_name=request_data.get("last_name")
             )
@@ -80,10 +91,7 @@ class AccountView(MethodView):
 
     @staticmethod
     def update_account_notification_preferences(account_id: str) -> ResponseReturnValue:
-        request_data = request.get_json()
-
-        if request_data is None:
-            raise AccountBadRequestError("Request body is required")
+        request_data = AccountView._get_request_body_as_object()
 
         for field in ["email_enabled", "push_enabled", "sms_enabled"]:
             if field in request_data and not isinstance(request_data[field], bool):

--- a/src/apps/backend/modules/authentication/rest_api/access_auth_middleware.py
+++ b/src/apps/backend/modules/authentication/rest_api/access_auth_middleware.py
@@ -9,25 +9,37 @@ from modules.authentication.errors import (
     InvalidAuthorizationHeaderError,
     UnauthorizedAccessError,
 )
+from modules.authentication.types import AccessTokenPayload
 
 
-def access_auth_middleware(next_func: Callable) -> Callable:
-    @wraps(next_func)
+def verify_request_access_token() -> AccessTokenPayload:
+    authorization_header = request.headers.get("Authorization")
+    if not authorization_header:
+        raise AuthorizationHeaderNotFoundError("Authorization header is missing.")
+
+    authorization_parts = authorization_header.split(" ")
+    if len(authorization_parts) != 2 or authorization_parts[0] != "Bearer" or not authorization_parts[1]:
+        raise InvalidAuthorizationHeaderError("Invalid authorization header.")
+
+    access_token_payload = AuthenticationService.verify_access_token(token=authorization_parts[1])
+    setattr(request, "account_id", access_token_payload.account_id)
+    return access_token_payload
+
+
+def enforce_account_ownership(account_id: str) -> None:
+    access_token_payload = verify_request_access_token()
+    if access_token_payload.account_id != account_id:
+        raise UnauthorizedAccessError("Unauthorized access.")
+
+
+def access_auth_middleware(next_function: Callable) -> Callable:
+    @wraps(next_function)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        auth_header = request.headers.get("Authorization")
-        if not auth_header:
-            raise AuthorizationHeaderNotFoundError("Authorization header is missing.")
+        if "account_id" in kwargs:
+            enforce_account_ownership(kwargs["account_id"])
+        else:
+            verify_request_access_token()
 
-        auth_scheme, auth_token = auth_header.split(" ")
-        if auth_scheme != "Bearer" or not auth_token:
-            raise InvalidAuthorizationHeaderError("Invalid authorization header.")
-
-        auth_payload = AuthenticationService.verify_access_token(token=auth_token)
-
-        if "account_id" in kwargs and auth_payload.account_id != kwargs["account_id"]:
-            raise UnauthorizedAccessError("Unauthorized access.")
-
-        setattr(request, "account_id", auth_payload.account_id)  # Set account_id attribute on request
-        return next_func(*args, **kwargs)
+        return next_function(*args, **kwargs)
 
     return wrapper

--- a/tests/modules/account/test_account_api/test_account_patch_api.py
+++ b/tests/modules/account/test_account_api/test_account_patch_api.py
@@ -2,7 +2,9 @@ import json
 
 from server import app
 
-from modules.account.types import AccountErrorCode
+from modules.account.account_service import AccountService
+from modules.account.types import AccountErrorCode, CreateAccountByUsernameAndPasswordParams
+from modules.authentication.types import AccessTokenErrorCode
 from tests.modules.account.base_test_account import BaseTestAccount
 
 ACCOUNT_URL = "http://127.0.0.1:8080/api/accounts"
@@ -14,7 +16,11 @@ class TestAccountPatchApi(BaseTestAccount):
         request_body = {"first_name": "new_first_name"}
 
         with app.test_client() as client:
-            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
 
             assert response.status_code == 200
             assert response.json
@@ -27,7 +33,11 @@ class TestAccountPatchApi(BaseTestAccount):
         request_body = {"last_name": "new_last_name"}
 
         with app.test_client() as client:
-            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
 
             assert response.status_code == 200
             assert response.json
@@ -40,7 +50,11 @@ class TestAccountPatchApi(BaseTestAccount):
         request_body = {"first_name": "new_first_name", "last_name": "new_last_name"}
 
         with app.test_client() as client:
-            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
 
             assert response.status_code == 200
             assert response.json
@@ -53,7 +67,11 @@ class TestAccountPatchApi(BaseTestAccount):
         request_body = {"first_name": "", "last_name": ""}
 
         with app.test_client() as client:
-            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
 
             assert response.status_code == 200
             assert response.json
@@ -61,6 +79,109 @@ class TestAccountPatchApi(BaseTestAccount):
             assert response.json.get("username") == self.account.username
             assert response.json.get("first_name") == ""
             assert response.json.get("last_name") == ""
+
+    def test_given_no_authorization_header_when_updating_profile_then_returns_unauthorized(self) -> None:
+        request_body = {"first_name": "new_first_name"}
+
+        with app.test_client() as client:
+            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.AUTHORIZATION_HEADER_NOT_FOUND
+
+    def test_given_invalid_access_token_when_updating_profile_then_returns_unauthorized(self) -> None:
+        request_body = {"first_name": "new_first_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": "Bearer invalid_token"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.ACCESS_TOKEN_INVALID
+
+    def test_given_authorization_header_without_a_token_when_updating_profile_then_returns_unauthorized(self) -> None:
+        request_body = {"first_name": "new_first_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": "Bearer"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.INVALID_AUTHORIZATION_HEADER
+
+    def test_given_authorization_header_with_extra_whitespace_when_updating_profile_then_returns_unauthorized(
+        self,
+    ) -> None:
+        request_body = {"first_name": "new_first_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{self.account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer  {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.INVALID_AUTHORIZATION_HEADER
+
+    def test_given_authenticated_account_when_updating_another_users_profile_then_returns_unauthorized(self) -> None:
+        other_account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="other_first_name", last_name="other_last_name", password="password", username="other_user"
+            )
+        )
+        request_body = {"first_name": "new_first_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{other_account.id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.UNAUTHORIZED_ACCESS
+
+    def test_given_authenticated_account_when_updating_a_nonexistent_account_then_returns_unauthorized(self) -> None:
+        nonexistent_account_id = "661e42ec98423703a299a899"
+        request_body = {"first_name": "new_first_name", "last_name": "new_last_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{nonexistent_account_id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.UNAUTHORIZED_ACCESS
+
+    def test_given_authenticated_account_when_updating_a_malformed_account_id_then_returns_unauthorized(self) -> None:
+        malformed_account_id = "invalid_object_id"
+        request_body = {"first_name": "new_first_name", "last_name": "new_last_name"}
+
+        with app.test_client() as client:
+            response = client.patch(
+                f"{ACCOUNT_URL}/{malformed_account_id}",
+                headers={**HEADERS, "Authorization": f"Bearer {self.access_token.token}"},
+                data=json.dumps(request_body),
+            )
+
+            assert response.status_code == 401
+            assert response.json
+            assert response.json.get("code") == AccessTokenErrorCode.UNAUTHORIZED_ACCESS
 
     def test_given_unrecognized_request_body_when_updating_profile_then_returns_bad_request(self) -> None:
         request_body = {"unexpected_field": "value"}
@@ -72,27 +193,34 @@ class TestAccountPatchApi(BaseTestAccount):
             assert response.json
             assert response.json.get("code") == AccountErrorCode.BAD_REQUEST
 
-    def test_given_nonexistent_account_id_when_updating_profile_then_returns_not_found(self) -> None:
-        nonexistent_account_id = "661e42ec98423703a299a899"
-        request_body = {"first_name": "new_first_name", "last_name": "new_last_name"}
-
+    def test_given_null_request_body_when_updating_profile_then_returns_bad_request(self) -> None:
         with app.test_client() as client:
-            response = client.patch(
-                f"{ACCOUNT_URL}/{nonexistent_account_id}", headers=HEADERS, data=json.dumps(request_body)
-            )
+            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(None))
 
-            assert response.status_code == 404
+            assert response.status_code == 400
             assert response.json
-            assert response.json.get("code") == AccountErrorCode.NOT_FOUND
-            assert f"We could not find an account with id: {nonexistent_account_id}" in response.json.get("message")
+            assert response.json.get("code") == AccountErrorCode.BAD_REQUEST
 
-    def test_given_malformed_account_id_when_updating_profile_then_returns_not_found(self) -> None:
-        malformed_account_id = "invalid_object_id"
-        request_body = {"first_name": "new_first_name", "last_name": "new_last_name"}
+    def test_given_numeric_request_body_when_updating_profile_then_returns_bad_request(self) -> None:
+        with app.test_client() as client:
+            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(123))
+
+            assert response.status_code == 400
+            assert response.json
+            assert response.json.get("code") == AccountErrorCode.BAD_REQUEST
+
+    def test_given_string_request_body_when_updating_profile_then_returns_bad_request(self) -> None:
+        with app.test_client() as client:
+            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps("first_name"))
+
+            assert response.status_code == 400
+            assert response.json
+            assert response.json.get("code") == AccountErrorCode.BAD_REQUEST
+
+    def test_given_reset_password_body_with_extra_keys_when_resetting_password_then_returns_not_found(self) -> None:
+        request_body = {"extra": "value", "new_password": "new_password", "token": "token"}
 
         with app.test_client() as client:
-            response = client.patch(
-                f"{ACCOUNT_URL}/{malformed_account_id}", headers=HEADERS, data=json.dumps(request_body)
-            )
+            response = client.patch(f"{ACCOUNT_URL}/{self.account.id}", headers=HEADERS, data=json.dumps(request_body))
 
             assert response.status_code == 404


### PR DESCRIPTION
## Summary

Closes #695. The profile-update branch of `PATCH /accounts/<account_id>` had no authentication, so any anonymous caller could rename any account by id.

The endpoint stays a single `PATCH /accounts/<account_id>` (it carries both the anonymous, token-validated password reset and the authenticated profile update), with authorization enforced per operation:

- Password reset (`{token, new_password}`): unchanged, authorized by the reset token.
- Profile update (`{first_name, last_name}`): now requires a valid access token and account ownership, via a new `enforce_account_ownership` helper extracted from `access_auth_middleware` (so `get`/`delete`/task routes are unchanged).

While in this code, the request handling on the touched routes was hardened to close the same class of 500s end to end:

- Strict `Authorization` header parsing: malformed headers (missing token, wrong scheme, stray/duplicate whitespace, multi-part) return 401, never 500.
- A shared `AccountView._get_request_body_as_object()`: non-object bodies (null, number, string, list) return 400 instead of 500. Applied to `patch` and notification-preferences.
- `ResetPasswordParams` is constructed from explicit fields instead of `**request_data`.

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

Contract note (consistent with #694): ownership is enforced before existence is checked, so a profile update against an id that is not the caller's own returns **401** rather than 404. This is intentional and avoids leaking whether an unowned id exists. The reset branch's not-found path is still covered by `test_reset_account_password_account_not_found`.

Deliberately out of scope (tracked separately, not regressions of this PR):

- Notification-preferences PATCH authentication is #696.
- `POST /accounts` malformed-body 500s are #699.

Verification: full suite passes; `npm run lint` and `npm run fmt:check` green.
