### PR TITLE
fix(kube): right-size workload resources to measured usage

### DIFF
--- a/lib/kube/preview/deployment.yaml
+++ b/lib/kube/preview/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: 250m
+              cpu: 150m
               memory: '400Mi'
             limits:
               cpu: 500m

--- a/lib/kube/preview/worker-deployment.yaml
+++ b/lib/kube/preview/worker-deployment.yaml
@@ -51,7 +51,7 @@ spec:
                 [ -f "$file" ] && export "$(basename "$file")=$(cat "$file")"
               done
               cd /app/src/apps/backend
-              pipenv run celery -A celery_app worker --loglevel=info --concurrency=2 --queues=critical,default,low -E
+              pipenv run celery -A celery_app worker --loglevel=info --concurrency=1 --queues=critical,default,low -E
           env:
             - name: APP_ENV
               value: 'preview'
@@ -69,10 +69,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 192Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 384Mi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -89,7 +89,7 @@ spec:
                 - -c
                 - cd /app/src/apps/backend && pipenv run celery -A celery_app inspect ping -d "celery@$(hostname)"
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 60
             timeoutSeconds: 10
           readinessProbe:
             exec:
@@ -98,7 +98,7 @@ spec:
                 - -c
                 - cd /app/src/apps/backend && pipenv run celery -A celery_app inspect ping -d "celery@$(hostname)"
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 30
             timeoutSeconds: 10
         # Celery Beat - Runs cron jobs
         - name: celery-beat
@@ -130,11 +130,11 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 25m
+              memory: 96Mi
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -192,11 +192,11 @@ spec:
             - containerPort: 5555
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 25m
+              memory: 96Mi
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -290,11 +290,11 @@ spec:
             - containerPort: 6379
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 25m
+              memory: 64Mi
             limits:
               cpu: 200m
-              memory: 512Mi
+              memory: 256Mi
           volumeMounts:
             - name: redis-data
               mountPath: /data

--- a/lib/kube/preview/worker-deployment.yaml
+++ b/lib/kube/preview/worker-deployment.yaml
@@ -304,6 +304,10 @@ spec:
             - redis-server
             - --appendonly
             - 'yes'
+            - --maxmemory
+            - '128mb'
+            - --maxmemory-policy
+            - 'allkeys-lru'
           livenessProbe:
             exec:
               command:

--- a/lib/kube/production/deployment.yaml
+++ b/lib/kube/production/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: 250m
+              cpu: 150m
               memory: '400Mi'
             limits:
               cpu: 500m

--- a/lib/kube/production/worker-deployment.yaml
+++ b/lib/kube/production/worker-deployment.yaml
@@ -51,7 +51,7 @@ spec:
                 [ -f "$file" ] && export "$(basename "$file")=$(cat "$file")"
               done
               cd /app/src/apps/backend
-              pipenv run celery -A celery_app worker --loglevel=info --concurrency=8 --queues=critical,default,low -E
+              pipenv run celery -A celery_app worker --loglevel=info --concurrency=2 --queues=critical,default,low -E
           env:
             - name: APP_ENV
               value: 'production'
@@ -68,11 +68,11 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 250m
+              memory: 384Mi
             limits:
-              cpu: 2000m
-              memory: 2Gi
+              cpu: 1000m
+              memory: 1Gi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -89,7 +89,7 @@ spec:
                 - -c
                 - cd /app/src/apps/backend && pipenv run celery -A celery_app inspect ping -d "celery@$(hostname)"
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 60
             timeoutSeconds: 10
           readinessProbe:
             exec:
@@ -98,7 +98,7 @@ spec:
                 - -c
                 - cd /app/src/apps/backend && pipenv run celery -A celery_app inspect ping -d "celery@$(hostname)"
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 30
             timeoutSeconds: 10
         # Celery Beat - Runs cron jobs (only one instance needed)
         - name: celery-beat
@@ -130,11 +130,11 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 25m
+              memory: 96Mi
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 100m
+              memory: 192Mi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -192,11 +192,11 @@ spec:
             - containerPort: 5555
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 25m
+              memory: 96Mi
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 200m
+              memory: 256Mi
           volumeMounts:
             - name: tmp
               mountPath: /app/tmp
@@ -290,11 +290,11 @@ spec:
             - containerPort: 6379
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 50m
+              memory: 64Mi
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 200m
+              memory: 512Mi
           volumeMounts:
             - name: redis-data
               mountPath: /data
@@ -305,7 +305,7 @@ spec:
             - --appendonly
             - 'yes'
             - --maxmemory
-            - '512mb'
+            - '256mb'
             - --maxmemory-policy
             - 'allkeys-lru'
           livenessProbe:


### PR DESCRIPTION
# Pull Request

## Summary

Our DigitalOcean audit found this cluster running 4 nodes (~$96/month) for an app with almost no traffic. The nodes aren't busy — they're *reserved*: containers ask Kubernetes for far more CPU/memory than they use, and the autoscaler counts what's asked, not what's used, so it can never shrink the cluster.

This PR sets each container's requests to what it actually uses (measured live), with headroom. Three changes:

1. **Right-sized requests and limits.** Examples: redis asked for 128–256Mi of memory but uses ~10Mi; flower asked for 100m CPU but uses 2m. The app's memory request was already accurate and stays unchanged.
2. **Fewer idle worker processes.** Production ran 8 celery processes for a queue that gets a few one-second jobs per minute — now 2 (previews: 1). Real load is handled by the worker autoscaler, which scales 1→5 pods.
3. **Lighter health checks.** The worker probes boot a full `pipenv run celery inspect ping` every 15–30 seconds — that was the single biggest CPU consumer on the cluster. Now every 30–60 seconds.

Result: a full environment fits one node per pool. Expected: **4 nodes → 2, about −$48/month**, with the autoscaler still adding a node while several PR previews run.

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

| Container | Uses (measured) | Request before → after |
|---|---|---|
| app | ~150m / 400Mi | 250m → 150m CPU (memory unchanged) |
| celery-worker (prod) | 315m / 341Mi at concurrency 8 | 500m/1Gi → 250m/384Mi |
| celery-beat | 5m / 72Mi | 50m/128Mi → 25m/96Mi |
| flower | 2m / 51Mi | 100m/256Mi → 25m/96Mi |
| redis | ~15m / 11Mi | 100m/256Mi → 50m/64Mi |

Preview redis also gets `--maxmemory 128mb` with `allkeys-lru` (matching production's pattern) so it evicts old keys instead of being OOM-killed at its new 256Mi limit.

This PR's own preview deployed with these values and runs clean: all pods healthy, zero restarts, app responding. After merge, production redeploys automatically; `kubectl top pods` and the absence of OOMKilled/CrashLoop events confirm the sizing.