### PR TITLE
fix: compute created_at/updated_at per-instance in UTC (closes #697)

### DIFF
--- a/src/apps/backend/modules/account/internal/account_writer.py
+++ b/src/apps/backend/modules/account/internal/account_writer.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from datetime import datetime
+from datetime import UTC, datetime
 
 from phonenumbers import is_valid_number, parse
 
@@ -16,6 +16,7 @@ from modules.account.types import (
     PhoneNumber,
     UpdateAccountProfileParams,
 )
+from modules.application.repository import FieldUpdates
 from modules.authentication.errors import OTPRequestFailedError
 
 
@@ -51,7 +52,9 @@ class AccountWriter:
     @staticmethod
     def update_password_by_account_id(account_id: str, password: str) -> Account:
         hashed_password = AccountUtil.hash_password(password=password)
-        updated_account = AccountRepository.update(account_id, {"hashed_password": hashed_password})
+        updated_account = AccountRepository.update(
+            account_id, {"hashed_password": hashed_password, "updated_at": datetime.now(UTC)}
+        )
         if updated_account is None:
             raise AccountWithIdNotFoundError(id=account_id)
 
@@ -59,13 +62,16 @@ class AccountWriter:
 
     @staticmethod
     def update_account_profile(*, account_id: str, params: UpdateAccountProfileParams) -> Account:
-        update_fields = {}
+        update_fields: FieldUpdates = {}
 
         if params.first_name is not None:
             update_fields["first_name"] = params.first_name
 
         if params.last_name is not None:
             update_fields["last_name"] = params.last_name
+
+        if update_fields:
+            update_fields["updated_at"] = datetime.now(UTC)
 
         updated_account = AccountRepository.update(account_id, update_fields)
         if updated_account is None:
@@ -79,7 +85,7 @@ class AccountWriter:
         # matching the previous `{"active": True}`-guarded update.
         AccountReader.get_account_by_id(params=AccountSearchByIdParams(id=account_id))
 
-        deletion_time = datetime.now()
+        deletion_time = datetime.now(UTC)
         AccountRepository.update_fields(account_id, {"active": False, "updated_at": deletion_time})
 
         return AccountDeletionResult(account_id=account_id, deleted_at=deletion_time, success=True)

--- a/src/apps/backend/modules/account/internal/store/account_model.py
+++ b/src/apps/backend/modules/account/internal/store/account_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
@@ -19,8 +18,6 @@ class AccountModel(BaseModel):
     username: str
 
     active: bool = True
-    created_at: Optional[datetime] = datetime.now()
-    updated_at: Optional[datetime] = datetime.now()
 
     @classmethod
     def from_bson(cls, bson_data: dict) -> "AccountModel":

--- a/src/apps/backend/modules/account/internal/store/account_repository.py
+++ b/src/apps/backend/modules/account/internal/store/account_repository.py
@@ -57,11 +57,13 @@ class AccountRepository(ApplicationRepository[Account, AccountQuery]):
     def from_doc(cls, doc: StoredDocument) -> Account:
         model = AccountModel.from_bson(doc)
         return Account(
-            id=str(model.id),
+            created_at=model.created_at,
             first_name=model.first_name,
-            last_name=model.last_name,
             hashed_password=model.hashed_password,
+            id=str(model.id),
+            last_name=model.last_name,
             phone_number=model.phone_number,
+            updated_at=model.updated_at,
             username=model.username,
         )
 

--- a/src/apps/backend/modules/account/types.py
+++ b/src/apps/backend/modules/account/types.py
@@ -89,6 +89,8 @@ class Account:
     hashed_password: str
     phone_number: Optional[PhoneNumber]
     username: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)

--- a/src/apps/backend/modules/application/base_model.py
+++ b/src/apps/backend/modules/application/base_model.py
@@ -1,9 +1,20 @@
-from dataclasses import asdict, dataclass
-from typing import Any
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Optional
 
 
-@dataclass
+@dataclass(kw_only=True)
 class BaseModel:
+    created_at: Optional[datetime] = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.created_at is not None and self.created_at.tzinfo is None:
+            self.created_at = self.created_at.replace(tzinfo=UTC)
+        if self.updated_at is None:
+            self.updated_at = self.created_at
+        elif self.updated_at.tzinfo is None:
+            self.updated_at = self.updated_at.replace(tzinfo=UTC)
 
     def to_bson(self) -> dict[str, Any]:
         data = asdict(self)

--- a/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
+++ b/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from datetime import UTC, datetime
 
 from modules.account.types import PhoneNumber
 from modules.authentication.errors import OTPExpiredError, OTPIncorrectError
@@ -12,7 +13,9 @@ class OTPWriter:
     def expire_previous_otps(phone_number: PhoneNumber) -> None:
         previous_otps = OTPRepository.query(OTPQuery(phone_number=phone_number, active=True))
         for otp in previous_otps:
-            OTPRepository.update_fields(otp.id, {"active": False, "status": str(OTPStatus.EXPIRED)})
+            OTPRepository.update_fields(
+                otp.id, {"active": False, "status": str(OTPStatus.EXPIRED), "updated_at": datetime.now(UTC)}
+            )
 
     @staticmethod
     def create_new_otp(*, params: CreateOTPParams) -> OTP:
@@ -35,7 +38,9 @@ class OTPWriter:
         if not otp.active:
             raise OTPExpiredError()
 
-        updated_otp = OTPRepository.update(otp.id, {"active": False, "status": str(OTPStatus.SUCCESS)})
+        updated_otp = OTPRepository.update(
+            otp.id, {"active": False, "status": str(OTPStatus.SUCCESS), "updated_at": datetime.now(UTC)}
+        )
         # update() returns None only if the row vanished between the read and the patch; the read above
         # found it, so it is present here.
         assert updated_otp is not None

--- a/src/apps/backend/modules/authentication/internals/otp/store/otp_model.py
+++ b/src/apps/backend/modules/authentication/internals/otp/store/otp_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
@@ -15,9 +14,6 @@ class OTPModel(BaseModel):
     otp_code: str
     phone_number: PhoneNumber
     status: str
-
-    created_at: Optional[datetime] = datetime.now()
-    updated_at: Optional[datetime] = datetime.now()
 
     @classmethod
     def from_bson(cls, bson_data: dict) -> "OTPModel":

--- a/src/apps/backend/modules/authentication/internals/otp/store/otp_repository.py
+++ b/src/apps/backend/modules/authentication/internals/otp/store/otp_repository.py
@@ -9,7 +9,7 @@ from modules.logger.logger import Logger
 OTP_VALIDATION_SCHEMA = {
     "$jsonSchema": {
         "bsonType": "object",
-        "required": ["otp_code", "phone_number", "status", "active"],
+        "required": ["active", "created_at", "otp_code", "phone_number", "status", "updated_at"],
         "properties": {
             "active": {"bsonType": "bool", "description": "must be a boolean and is required"},
             "otp_code": {"bsonType": "string", "description": "must be a string and is required"},
@@ -56,11 +56,13 @@ class OTPRepository(ApplicationRepository[OTP, OTPQuery]):
     def from_doc(cls, doc: StoredDocument) -> OTP:
         model = OTPModel.from_bson(doc)
         return OTP(
+            active=model.active,
+            created_at=model.created_at,
             id=str(model.id),
             otp_code=model.otp_code,
             phone_number=model.phone_number,
             status=model.status,
-            active=model.active,
+            updated_at=model.updated_at,
         )
 
     @classmethod

--- a/src/apps/backend/modules/authentication/internals/password_reset_token/password_reset_token_writer.py
+++ b/src/apps/backend/modules/authentication/internals/password_reset_token/password_reset_token_writer.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from modules.authentication.errors import PasswordResetTokenNotFoundError
 from modules.authentication.internals.password_reset_token.password_reset_token_util import PasswordResetTokenUtil
 from modules.authentication.internals.password_reset_token.store.password_reset_token_repository import (
@@ -18,7 +20,9 @@ class PasswordResetTokenWriter:
 
     @staticmethod
     def set_password_reset_token_as_used(password_reset_token_id: str) -> PasswordResetToken:
-        updated_token = PasswordResetTokenRepository.update(password_reset_token_id, {"is_used": True})
+        updated_token = PasswordResetTokenRepository.update(
+            password_reset_token_id, {"is_used": True, "updated_at": datetime.now(UTC)}
+        )
         if updated_token is None:
             raise PasswordResetTokenNotFoundError()
 

--- a/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_model.py
+++ b/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_model.py
@@ -21,10 +21,12 @@ class PasswordResetTokenModel(BaseModel):
     def from_bson(cls, bson_data: dict) -> "PasswordResetTokenModel":
         return cls(
             account=bson_data.get("account"),
+            created_at=bson_data.get("created_at"),
             expires_at=bson_data.get("expires_at", ""),
             id=bson_data.get("_id"),
             is_used=bson_data.get("is_used", ""),
             token=bson_data.get("token", ""),
+            updated_at=bson_data.get("updated_at"),
         )
 
     @staticmethod

--- a/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_repository.py
+++ b/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_repository.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from bson import ObjectId
@@ -16,12 +16,14 @@ from modules.logger.logger import Logger
 PASSWORD_RESET_TOKEN_VALIDATION_SCHEMA = {
     "$jsonSchema": {
         "bsonType": "object",
-        "required": ["account", "expires_at", "token", "is_used"],
+        "required": ["account", "expires_at", "is_used", "token"],
         "properties": {
             "account": {"bsonType": "objectId", "description": "must be an ObjectId and is required"},
+            "created_at": {"bsonType": "date"},
             "expires_at": {"bsonType": "date", "description": "must be a valid date and is required"},
             "is_used": {"bsonType": "bool", "description": "must be a boolean and is required"},
             "token": {"bsonType": "string", "description": "must be a string and is required"},
+            "updated_at": {"bsonType": "date"},
             "_id": {"bsonType": "objectId", "description": "must be an ObjectId"},
         },
     }
@@ -54,12 +56,14 @@ class PasswordResetTokenRepository(ApplicationRepository[PasswordResetToken, Pas
     def from_doc(cls, doc: StoredDocument) -> PasswordResetToken:
         model = PasswordResetTokenModel.from_bson(doc)
         return PasswordResetToken(
-            id=str(model.id),
             account=str(model.account),
-            token=model.token,
+            created_at=model.created_at,
             expires_at=str(model.expires_at),
-            is_used=model.is_used,
+            id=str(model.id),
             is_expired=PasswordResetTokenUtil.is_token_expired(model.expires_at),
+            is_used=model.is_used,
+            token=model.token,
+            updated_at=model.updated_at,
         )
 
     @classmethod
@@ -80,11 +84,14 @@ class PasswordResetTokenRepository(ApplicationRepository[PasswordResetToken, Pas
         # The stored document keys `account` as an ObjectId and `expires_at` as a real date — a store-shaped
         # write the generic create()/to_doc() (which round-trips the string-typed domain entity) cannot
         # express, so it stays on the repository (see docs/backend-architecture.md).
+        creation_time = datetime.now(UTC)
         doc: StoredDocument = {
             "account": ObjectId(account_id),
+            "created_at": creation_time,
             "expires_at": expires_at,
-            "token": token_hash,
             "is_used": False,
+            "token": token_hash,
+            "updated_at": creation_time,
         }
         result = cls.collection().insert_one(doc)
         return cls.from_doc({**doc, "_id": result.inserted_id})

--- a/src/apps/backend/modules/authentication/types.py
+++ b/src/apps/backend/modules/authentication/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Optional, Union
 
@@ -53,6 +54,8 @@ class PasswordResetToken:
     is_expired: bool
     is_used: bool
     token: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)
@@ -86,6 +89,8 @@ class OTP:
     # An OTP is active until it is consumed (verified) or superseded by a newer one; verification reads
     # this to tell a correct-but-expired code from an incorrect one.
     active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)

--- a/src/apps/backend/modules/notification/internals/store/account_notification_preferences_model.py
+++ b/src/apps/backend/modules/notification/internals/store/account_notification_preferences_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
@@ -15,8 +14,6 @@ class AccountNotificationPreferencesModel(BaseModel):
     push_enabled: bool = True
     sms_enabled: bool = True
     active: bool = True
-    created_at: Optional[datetime] = datetime.now()
-    updated_at: Optional[datetime] = datetime.now()
 
     @classmethod
     def from_bson(cls, bson_data: dict) -> "AccountNotificationPreferencesModel":

--- a/src/apps/backend/modules/notification/internals/store/account_notification_preferences_repository.py
+++ b/src/apps/backend/modules/notification/internals/store/account_notification_preferences_repository.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pymongo import ReturnDocument
 from pymongo.collection import Collection
@@ -76,9 +76,11 @@ class AccountNotificationPreferencesRepository(
         model = AccountNotificationPreferencesModel.from_bson(doc)
         return AccountNotificationPreferences(
             account_id=model.account_id,
+            created_at=model.created_at,
             email_enabled=model.email_enabled,
             push_enabled=model.push_enabled,
             sms_enabled=model.sms_enabled,
+            updated_at=model.updated_at,
         )
 
     @classmethod
@@ -108,7 +110,7 @@ class AccountNotificationPreferencesRepository(
         # this $set has no generic-verb equivalent and stays on the repository (see backend-architecture.md).
         updated = cls.collection().find_one_and_update(
             {"account_id": account_id, "active": True},
-            {"$set": {**fields, "updated_at": datetime.now()}},
+            {"$set": {**fields, "updated_at": datetime.now(UTC)}},
             return_document=ReturnDocument.AFTER,
         )
         return cls.from_doc(updated)

--- a/src/apps/backend/modules/notification/types.py
+++ b/src/apps/backend/modules/notification/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from modules.account.types import PhoneNumber
@@ -29,6 +30,8 @@ class AccountNotificationPreferences:
     email_enabled: bool = True
     push_enabled: bool = True
     sms_enabled: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)

--- a/src/apps/backend/modules/task/internal/store/task_model.py
+++ b/src/apps/backend/modules/task/internal/store/task_model.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
 
 from bson import ObjectId
@@ -13,9 +12,7 @@ class TaskModel(BaseModel):
     description: str
     title: str
     active: bool = True
-    created_at: Optional[datetime] = datetime.now()
     id: Optional[ObjectId | str] = None
-    updated_at: Optional[datetime] = datetime.now()
 
     @classmethod
     def from_bson(cls, bson_data: dict) -> "TaskModel":

--- a/src/apps/backend/modules/task/internal/store/task_repository.py
+++ b/src/apps/backend/modules/task/internal/store/task_repository.py
@@ -51,7 +51,14 @@ class TaskRepository(ApplicationRepository[Task, TaskQuery]):
     @classmethod
     def from_doc(cls, doc: StoredDocument) -> Task:
         model = TaskModel.from_bson(doc)
-        return Task(id=str(model.id), account_id=model.account_id, description=model.description, title=model.title)
+        return Task(
+            account_id=model.account_id,
+            created_at=model.created_at,
+            description=model.description,
+            id=str(model.id),
+            title=model.title,
+            updated_at=model.updated_at,
+        )
 
     @classmethod
     def to_doc(cls, entity: Task) -> StoredDocument:

--- a/src/apps/backend/modules/task/internal/task_writer.py
+++ b/src/apps/backend/modules/task/internal/task_writer.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from modules.task.internal.store.task_repository import TaskRepository
 from modules.task.internal.task_reader import TaskReader
@@ -24,7 +24,7 @@ class TaskWriter:
         TaskReader.get_task(params=GetTaskParams(account_id=params.account_id, task_id=params.task_id))
 
         TaskRepository.update_fields(
-            params.task_id, {"description": params.description, "title": params.title, "updated_at": datetime.now()}
+            params.task_id, {"description": params.description, "title": params.title, "updated_at": datetime.now(UTC)}
         )
 
         return TaskReader.get_task(params=GetTaskParams(account_id=params.account_id, task_id=params.task_id))
@@ -34,7 +34,7 @@ class TaskWriter:
         # Confirm the task exists for this account (raises if not) before soft-deleting it.
         task = TaskReader.get_task(params=GetTaskParams(account_id=params.account_id, task_id=params.task_id))
 
-        deletion_time = datetime.now()
+        deletion_time = datetime.now(UTC)
         TaskRepository.update_fields(task.id, {"active": False, "updated_at": deletion_time})
 
         return TaskDeletionResult(task_id=params.task_id, deleted_at=deletion_time, success=True)

--- a/src/apps/backend/modules/task/types.py
+++ b/src/apps/backend/modules/task/types.py
@@ -11,6 +11,8 @@ class Task:
     account_id: str
     description: str
     title: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(frozen=True)

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from server import app
@@ -197,6 +197,61 @@ class TestAccountService(BaseTestAccount):
         assert deletion_result.success is True
         assert deletion_result.deleted_at is not None
         assert isinstance(deletion_result.deleted_at, datetime)
+
+    def test_given_account_details_when_creating_account_then_created_at_and_updated_at_reflect_creation_time(
+        self,
+    ) -> None:
+        before = datetime.now(UTC)
+        created_account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="timestamp_username"
+            )
+        )
+        after = datetime.now(UTC)
+
+        assert created_account.created_at is not None
+        assert created_account.updated_at is not None
+        assert created_account.created_at.tzinfo is not None
+        assert created_account.updated_at.tzinfo is not None
+        assert created_account.created_at.utcoffset() == timedelta(0)
+        assert created_account.updated_at.utcoffset() == timedelta(0)
+        assert created_account.created_at == created_account.updated_at
+        assert before <= created_account.created_at <= after
+        assert before <= created_account.updated_at <= after
+
+    def test_given_existing_account_when_updating_profile_then_updated_at_reflects_update_time(self) -> None:
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        before = datetime.now(UTC)
+        updated_account = AccountService.update_account_profile(
+            account_id=account.id, params=UpdateAccountProfileParams(first_name="updated_first_name")
+        )
+        after = datetime.now(UTC)
+
+        assert updated_account.updated_at is not None
+        assert updated_account.created_at is not None
+        assert before - timedelta(milliseconds=1) <= updated_account.updated_at <= after
+        assert updated_account.updated_at > updated_account.created_at
+
+    def test_given_existing_account_when_deleting_account_then_deleted_at_reflects_deletion_time_in_utc(self) -> None:
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        before = datetime.now(UTC)
+        deletion_result = AccountService.delete_account(account_id=account.id)
+        after = datetime.now(UTC)
+
+        assert deletion_result.deleted_at is not None
+        assert deletion_result.deleted_at.tzinfo is not None
+        assert deletion_result.deleted_at.utcoffset() == timedelta(0)
+        assert before <= deletion_result.deleted_at <= after
 
     def test_delete_account_not_found(self) -> None:
         non_existent_account_id = "5f7b1b7b4f3b9b1b3f3b9b1b"

--- a/tests/modules/account/test_notification_preferences_service.py
+++ b/tests/modules/account/test_notification_preferences_service.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from modules.account.account_service import AccountService
 from modules.account.types import (
     CreateAccountByPhoneNumberParams,
@@ -10,6 +12,45 @@ from tests.modules.account.base_test_account import BaseTestAccount
 
 
 class TestNotificationPreferencesService(BaseTestAccount):
+    def test_given_account_details_when_creating_account_then_notification_preferences_timestamps_reflect_creation_time(
+        self,
+    ) -> None:
+        before = datetime.now(UTC)
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="timestamp_username"
+            )
+        )
+        after = datetime.now(UTC)
+
+        preferences = NotificationService.get_account_notification_preferences_by_account_id(account_id=account.id)
+
+        assert preferences.created_at is not None
+        assert preferences.updated_at is not None
+        assert preferences.created_at.utcoffset() == timedelta(0)
+        assert preferences.updated_at.utcoffset() == timedelta(0)
+        assert preferences.created_at == preferences.updated_at
+        assert before - timedelta(milliseconds=1) <= preferences.created_at <= after
+        assert before - timedelta(milliseconds=1) <= preferences.updated_at <= after
+
+    def test_given_existing_notification_preferences_when_updating_preferences_then_updated_at_reflects_update_time(
+        self,
+    ) -> None:
+        update_preferences = CreateOrUpdateAccountNotificationPreferencesParams(
+            email_enabled=False, push_enabled=True, sms_enabled=False
+        )
+
+        before = datetime.now(UTC)
+        preferences = NotificationService.create_or_update_account_notification_preferences(
+            account_id=self.account.id, preferences=update_preferences
+        )
+        after = datetime.now(UTC)
+
+        assert preferences.created_at is not None
+        assert preferences.updated_at is not None
+        assert before - timedelta(milliseconds=1) <= preferences.updated_at <= after
+        assert preferences.updated_at > preferences.created_at
+
     def test_get_notification_preferences_returns_existing_preferences(self) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(

--- a/tests/modules/authentication/test_access_token_api.py
+++ b/tests/modules/authentication/test_access_token_api.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime, timedelta
 
 from server import app
 
@@ -74,6 +75,50 @@ class TestAccessTokenApi(BaseTestAccessToken):
             assert response.status_code == 404
             assert response.json
             assert response.json.get("code") == AccountErrorCode.NOT_FOUND
+
+    def test_given_phone_number_when_creating_one_time_password_then_created_at_and_updated_at_reflect_creation_time(
+        self,
+    ) -> None:
+        phone_number = {"country_code": "+91", "phone_number": "9999999999"}
+        account = AccountWriter.create_account_by_phone_number(
+            params=CreateAccountByPhoneNumberParams(phone_number=PhoneNumber(**phone_number))
+        )
+
+        before = datetime.now(UTC)
+        one_time_password = AuthenticationService.create_otp(
+            params=CreateOTPParams(phone_number=PhoneNumber(**phone_number)), account_id=account.id
+        )
+        after = datetime.now(UTC)
+
+        assert one_time_password.created_at is not None
+        assert one_time_password.updated_at is not None
+        assert one_time_password.created_at.tzinfo is not None
+        assert one_time_password.updated_at.tzinfo is not None
+        assert one_time_password.created_at.utcoffset() == timedelta(0)
+        assert one_time_password.updated_at.utcoffset() == timedelta(0)
+        assert one_time_password.created_at == one_time_password.updated_at
+        assert before <= one_time_password.created_at <= after
+        assert before <= one_time_password.updated_at <= after
+
+    def test_given_existing_one_time_password_when_verifying_then_updated_at_reflects_verification_time(self) -> None:
+        phone_number = {"country_code": "+91", "phone_number": "9999999999"}
+        account = AccountWriter.create_account_by_phone_number(
+            params=CreateAccountByPhoneNumberParams(phone_number=PhoneNumber(**phone_number))
+        )
+        one_time_password = AuthenticationService.create_otp(
+            params=CreateOTPParams(phone_number=PhoneNumber(**phone_number)), account_id=account.id
+        )
+
+        before = datetime.now(UTC)
+        verified_one_time_password = AuthenticationService.verify_otp(
+            params=VerifyOTPParams(phone_number=PhoneNumber(**phone_number), otp_code=one_time_password.otp_code)
+        )
+        after = datetime.now(UTC)
+
+        assert verified_one_time_password.updated_at is not None
+        assert verified_one_time_password.created_at is not None
+        assert before - timedelta(milliseconds=1) <= verified_one_time_password.updated_at <= after
+        assert verified_one_time_password.updated_at > verified_one_time_password.created_at
 
     def test_get_access_token_by_phone_number_and_otp(self) -> None:
         phone_number = {"country_code": "+91", "phone_number": "9999999999"}

--- a/tests/modules/authentication/test_password_reset_token_api.py
+++ b/tests/modules/authentication/test_password_reset_token_api.py
@@ -1,11 +1,12 @@
 import json
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 
 from server import app
 
 from modules.account.account_service import AccountService
 from modules.account.errors import AccountBadRequestError, AccountNotFoundError
-from modules.account.types import CreateAccountByUsernameAndPasswordParams
+from modules.account.types import CreateAccountByUsernameAndPasswordParams, ResetPasswordParams
 from modules.authentication.authentication_service import AuthenticationService
 from modules.authentication.errors import PasswordResetTokenNotFoundError
 from modules.authentication.internals.password_reset_token.password_reset_token_util import PasswordResetTokenUtil
@@ -45,6 +46,72 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertTrue(mock_send_email.called)
             self.assertIn("password_reset_link", mock_send_email.call_args.kwargs["params"].template_data)
             self.assertEqual(response.json["account"], account.id)
+
+    @mock.patch.object(EmailService, "send_email_for_account")
+    def test_given_account_when_creating_password_reset_token_then_created_at_and_updated_at_reflect_creation_time(
+        self, mock_send_email
+    ) -> None:
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+
+        before = datetime.now(UTC)
+        password_reset_token = AuthenticationService.create_password_reset_token(account)
+        after = datetime.now(UTC)
+
+        assert password_reset_token.created_at is not None
+        assert password_reset_token.updated_at is not None
+        assert password_reset_token.created_at.tzinfo is not None
+        assert password_reset_token.updated_at.tzinfo is not None
+        assert password_reset_token.created_at.utcoffset() == timedelta(0)
+        assert password_reset_token.updated_at.utcoffset() == timedelta(0)
+        assert password_reset_token.created_at == password_reset_token.updated_at
+        assert before <= password_reset_token.created_at <= after
+        assert before <= password_reset_token.updated_at <= after
+
+    def test_given_valid_reset_token_when_resetting_password_then_account_updated_at_reflects_update_time(self) -> None:
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+        token = PasswordResetTokenUtil.generate_password_reset_token()
+        PasswordResetTokenWriter.create_password_reset_token(account.id, token)
+
+        before = datetime.now(UTC)
+        updated_account = AccountService.reset_account_password(
+            params=ResetPasswordParams(account_id=account.id, new_password="new_password", token=token)
+        )
+        after = datetime.now(UTC)
+
+        assert updated_account.updated_at is not None
+        assert updated_account.created_at is not None
+        assert before - timedelta(milliseconds=1) <= updated_account.updated_at <= after
+        assert updated_account.updated_at > updated_account.created_at
+
+    def test_given_existing_reset_token_when_marking_used_then_updated_at_reflects_update_time(self) -> None:
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            )
+        )
+        token = PasswordResetTokenUtil.generate_password_reset_token()
+        PasswordResetTokenWriter.create_password_reset_token(account.id, token)
+        password_reset_token = AuthenticationService.get_password_reset_token_by_account_id(account_id=account.id)
+
+        before = datetime.now(UTC)
+        used_password_reset_token = AuthenticationService.set_password_reset_token_as_used_by_id(
+            password_reset_token.id
+        )
+        after = datetime.now(UTC)
+
+        assert used_password_reset_token.is_used
+        assert used_password_reset_token.updated_at is not None
+        assert used_password_reset_token.created_at is not None
+        assert before - timedelta(milliseconds=1) <= used_password_reset_token.updated_at <= after
+        assert used_password_reset_token.updated_at > used_password_reset_token.created_at
 
     @mock.patch.object(EmailService, "send_email_for_account")
     def test_create_password_reset_token_account_not_found(self, mock_send_email):

--- a/tests/modules/task/test_task_service.py
+++ b/tests/modules/task/test_task_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 from modules.application.common.types import PaginationParams
 from modules.task.errors import TaskNotFoundError
@@ -113,6 +113,39 @@ class TestTaskService(BaseTestTask):
         assert updated_task.title == "Updated Title"
         assert updated_task.description == "Updated Description"
 
+    def test_given_task_details_when_creating_task_then_created_at_and_updated_at_reflect_creation_time(self) -> None:
+        before = datetime.now(UTC)
+        created_task = self.create_test_task(account_id=self.account.id)
+        after = datetime.now(UTC)
+
+        assert created_task.created_at is not None
+        assert created_task.updated_at is not None
+        assert created_task.created_at.tzinfo is not None
+        assert created_task.updated_at.tzinfo is not None
+        assert created_task.created_at.utcoffset() == timedelta(0)
+        assert created_task.updated_at.utcoffset() == timedelta(0)
+        assert created_task.created_at == created_task.updated_at
+        assert before <= created_task.created_at <= after
+        assert before <= created_task.updated_at <= after
+
+    def test_given_existing_task_when_updating_task_then_updated_at_reflects_update_time(self) -> None:
+        created_task = self.create_test_task(account_id=self.account.id)
+        update_params = UpdateTaskParams(
+            account_id=self.account.id,
+            task_id=created_task.id,
+            title="Updated Title",
+            description="Updated Description",
+        )
+
+        before = datetime.now(UTC)
+        updated_task = TaskService.update_task(params=update_params)
+        after = datetime.now(UTC)
+
+        assert updated_task.updated_at is not None
+        assert updated_task.created_at is not None
+        assert before - timedelta(milliseconds=1) <= updated_task.updated_at <= after
+        assert updated_task.updated_at > updated_task.created_at
+
     def test_update_task_not_found(self) -> None:
         non_existent_task_id = "507f1f77bcf86cd799439011"
         update_params = UpdateTaskParams(
@@ -141,6 +174,19 @@ class TestTaskService(BaseTestTask):
         get_params = GetTaskParams(account_id=self.account.id, task_id=created_task.id)
         with self.assertRaises(TaskNotFoundError):
             TaskService.get_task(params=get_params)
+
+    def test_given_existing_task_when_deleting_task_then_deleted_at_reflects_deletion_time_in_utc(self) -> None:
+        created_task = self.create_test_task(account_id=self.account.id)
+        delete_params = DeleteTaskParams(account_id=self.account.id, task_id=created_task.id)
+
+        before = datetime.now(UTC)
+        deletion_result = TaskService.delete_task(params=delete_params)
+        after = datetime.now(UTC)
+
+        assert deletion_result.deleted_at is not None
+        assert deletion_result.deleted_at.tzinfo is not None
+        assert deletion_result.deleted_at.utcoffset() == timedelta(0)
+        assert before <= deletion_result.deleted_at <= after
 
     def test_delete_task_not_found(self) -> None:
         non_existent_task_id = "507f1f77bcf86cd799439011"


### PR DESCRIPTION
## Summary

Store model timestamps (`created_at` / `updated_at`) were declared as dataclass field defaults using a bare `datetime.now()`. A default expression is evaluated once, at class-definition (import) time, so every row written in a process received the identical import-time value instead of its real creation or update time.

This moves `created_at` / `updated_at` onto `BaseModel` with a per-instance `field(default_factory=lambda: datetime.now(UTC))`, so each row is stamped at construction. Supporting correctness and consistency work:

- `BaseModel.__post_init__` normalizes timestamps to timezone-aware UTC on hydration (pymongo returns naive datetimes), so a field has one shape whether freshly created or reloaded, and `updated_at` defaults to `created_at` on a fresh row.
- `updated_at` is now advanced on every update path, all in UTC: account profile and password, task update, notification-preferences update, one-time-password expire and verify, and both soft-deletes.
- `created_at` / `updated_at` are exposed on the domain objects and hydrated in every repository, so callers and API responses see the real timestamps.
- All four affected models plus `PasswordResetToken` are covered, and the OTP schema now requires the fields for consistency.

**PasswordResetToken schema:** the two fields are added as `date` properties but deliberately kept out of `required`. They are net-new to this collection, and under `validationLevel: "strict"` MongoDB re-validates the full document on every update, so requiring them would fail the `is_used` update for any reset token created before this deploy (no backfill migration exists). New tokens always write both fields.

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

`npm run fmt:check`, `npm run lint` (mypy strict + pylint 10.00/10), and `npm run test` (188 passed) are green.

New service-level tests cover create, update, and delete timestamp behavior across all five entities, asserting per-instance generation, UTC offset, and that fresh rows have `created_at == updated_at`. Tests assert on the returned domain objects with no repository access: create paths use microsecond-precision windows, reload paths allow a one-millisecond slack for MongoDB date truncation.

Closes #697
