### PR TITLE
fix: require the JWT signing key from an environment secret (closes #693)

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -1,3 +1,6 @@
+accounts:
+  token_signing_key: 'ACCOUNTS_TOKEN_SIGNING_KEY'
+
 mailer:
   default_email: 'DEFAULT_EMAIL'
   default_email_name: 'DEFAULT_EMAIL_NAME'

--- a/config/default.yml
+++ b/config/default.yml
@@ -17,7 +17,6 @@ datadog:
   log_level: 'info'
 
 accounts:
-  token_signing_key: 'JWT_TOKEN'
   token_expiry_days: 1
   token_expires_in_seconds: 3600
   create_test_user_account: false

--- a/config/development.yml
+++ b/config/development.yml
@@ -11,6 +11,9 @@ celery:
 worker:
   health_check_url: 'http://localhost:8080/api/'
 
+accounts:
+  token_signing_key: 'insecure-local-development-signing-key'
+
 sms:
   enabled: false
 
@@ -21,14 +24,5 @@ public:
   default_otp:
     enabled: true
     code: '1234'
-
-account:
-  enable_bootstrap_tasks: true
-  create_test_user_account: true
-  test_user:
-    first_name: 'Dev'
-    last_name: 'User'
-    username: 'dev@example.com'
-    password: 'devpassword'
 
 BOOTSTRAP_APP: true

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -16,13 +16,4 @@ public:
     enabled: true
     code: '1234'
 
-account:
-  enable_bootstrap_tasks: true
-  create_test_user_account: true
-  test_user:
-    first_name: 'Preview'
-    last_name: 'User'
-    username: 'preview@example.com'
-    password: 'previewpassword'
-
 BOOTSTRAP_APP: true

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -8,6 +8,9 @@ celery:
 worker:
   health_check_url: 'http://localhost:8080/api/'
 
+accounts:
+  token_signing_key: 'insecure-local-testing-signing-key'
+
 mailer:
   default_email: 'DEFAULT_EMAIL'
   default_email_name: 'DEFAULT_EMAIL_NAME'

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -64,6 +64,15 @@ _Empty or unset secrets are ignored and fallback to the value defined in the cor
 
 ## Required Secrets by Category
 
+### Backend Authentication
+
+Required in every deployed environment. `default.yml` ships no signing key, so `preview` and `production`
+resolve it only from this secret; without it the backend cannot sign or verify access tokens:
+
+| Doppler Secret               | Config Key                   | Description                                                               |
+| ---------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `ACCOUNTS_TOKEN_SIGNING_KEY` | `accounts.token_signing_key` | JWT signing key (HS256); use a high-entropy random string per environment |
+
 ### Backend Datadog Logging
 
 Required for backend log forwarding to Datadog (when `logger.transports` includes `'datadog'`):


### PR DESCRIPTION
## Summary

Closes #693.

`accounts.token_signing_key` was the only application secret with no environment-variable override wiring, and `default.yml` shipped a static placeholder (`'JWT_TOKEN'`) used verbatim in every environment. A project bootstrapped from this template would silently sign production access tokens with a publicly known constant, allowing an attacker to forge a token for any account.

This change makes the signing key resolve only from a real secret in deployed environments:

- Map `accounts.token_signing_key` to the `ACCOUNTS_TOKEN_SIGNING_KEY` secret in `custom-environment-variables.yml`, consistent with the other secrets.
- Remove the shipped signing key from `default.yml` so `preview` and `production` resolve it only from the secret, never from a committed constant.
- `development.yml` and `testing.yml` supply their own local signing keys, so local runs and the test suite keep working without touching the deployed path.
- Document the required secret in `docs/secrets.md`.

Also removes the dead singular `account:` blocks from `development.yml` and `preview.yml`: nothing reads `account.` (the code reads `accounts.`), so those blocks never took effect and were misleading configuration.

### Deploy notes

- Every deployed environment must have `ACCOUNTS_TOKEN_SIGNING_KEY` set in Doppler before rollout. Without it, token operations fail closed (`MissingKeyError`) rather than signing with an insecure default.
- Rotating away from any prior `'JWT_TOKEN'`-signed tokens invalidates in-flight access tokens, so users signed in under the old key will re-authenticate once.

---

## Pre-Merge Checklist

- [x] Tests pass
- [x] Self-reviewed
- [x] AI code review completed (if applicable)

---

## Additional Context

The fix is configuration-only, since the defect was a configuration-wiring gap. Runtime behavior is covered by the existing `TestAuthenticationService` access-token round-trip tests, which exercise both the sign and verify paths through `accounts.token_signing_key`; they would fail if the key were not resolvable in the testing environment. Verified manually that a deployed environment without the secret fails closed, that the `ACCOUNTS_TOKEN_SIGNING_KEY` override resolves, and that local environments sign and verify tokens with their committed keys.
