### PR TITLE
chore: add self-review skill for automated PR improvements

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -86,15 +86,28 @@ gh api graphql -f query='
   --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
 ```
 
-Reply on a thread with `gh api .../pulls/<pr>/comments/<comment-id>/replies -f body=...`, then resolve it by
-its thread id (`PRRT_…`, from the query above):
+Reply and resolve with the thread id (`PRRT_…`) the query above already returned — both mutations take it, so
+stay on GraphQL for the whole step:
 
 ```bash
+# reply
+gh api graphql -f query='
+  mutation($threadId:ID!, $body:String!) {
+    addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$threadId, body:$body}) {
+      comment { url }
+    }
+  }' -f threadId=<thread-id> -f body='<reply>'
+
+# then resolve
 gh api graphql -f query='
   mutation($threadId:ID!) {
     resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } }
   }' -f threadId=<thread-id>
 ```
+
+Do not reach for the REST replies endpoint (`.../pulls/<pr>/comments/<comment-id>/replies`) — it is keyed by
+a comment's numeric `databaseId`, which is neither the thread id nor anything `reviewThreads` returns by
+default, so mixing the two APIs is how this step fails.
 
 Resolve only threads you have actually addressed — never blanket-resolve to clear the stop condition.
 

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -68,6 +68,36 @@ For every open review comment:
 - Reply with a concise explanation of the resolution (or the rationale if no change is required).
 - Resolve the conversation.
 
+**Whether a thread is resolved is a GraphQL-only fact.** The REST payload behind `gh pr view --json comments`
+and `gh api .../pulls/<pr>/comments` carries no resolution state, so it cannot tell an open thread from a
+settled one — read threads through `reviewThreads` instead, or the "no unresolved comments" stop condition
+is not something you can actually check:
+
+```bash
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
+      reviewThreads(first:100) { nodes {
+        id isResolved isOutdated
+        comments(first:10) { nodes { path line body author { login } } }
+      } }
+    } }
+  }' -f owner=<owner> -f repo=<repo> -F pr=<pr> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
+```
+
+Reply on a thread with `gh api .../pulls/<pr>/comments/<comment-id>/replies -f body=...`, then resolve it by
+its thread id (`PRRT_…`, from the query above):
+
+```bash
+gh api graphql -f query='
+  mutation($threadId:ID!) {
+    resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } }
+  }' -f threadId=<thread-id>
+```
+
+Resolve only threads you have actually addressed — never blanket-resolve to clear the stop condition.
+
 ### 5. Improve the code the PR touches
 
 Refactor to keep the codebase maintainable, but **only within the PR's existing footprint** — the lines and
@@ -103,6 +133,10 @@ all as blocking, whether or not branch protection currently enforces them. GitHu
 - **`ci / codereview`** — the AI code-review gate (`anthropics/claude-code-action`, reading `AGENTS.md`).
   It fails when it posts inline findings, so address/resolve every finding it raises.
 - **`ci / scan`** — Trivy (filesystem / IaC / Docker) and Checkov security scans; fails on HIGH/CRITICAL.
+
+One more check reports outside `ci.yml`: **`label`** (`.github/workflows/pr-labeler.yml`) derives the type and
+semver labels from the PR title and fails when the title is not Conventional Commits. It is the one check no
+commit can fix — repair it with `gh pr edit <pr> --title '<type>: <subject>'`, not by pushing code.
 
 Reproduce failures locally before pushing with `npm run lint`, `npm run fmt:check`, and `make run-test`
 (or `npm run test`).

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: self-review
+description: >-
+  Autonomously review and improve a pull request in a loop until no significant improvements
+  remain, all GitHub review comments are resolved, and every CI check is green. Use after a
+  PR is raised, when the user wants an agent to self-heal / polish it. Pass the PR link or number
+  as an argument.
+---
+
+# Self-Review
+
+Continuously review and improve the pull request passed as an argument (a PR link or number) until
+**all** of these hold:
+
+- A fresh review of the updated PR identifies no further significant improvements.
+- No unresolved GitHub review comments remain.
+- Every CI check on the PR is green.
+
+Begin another iteration immediately after every push, and react as soon as new information lands. **Never
+`sleep`-and-poll in a loop** — that burns API quota against CI jobs that take minutes. Block on the result
+instead: `gh pr checks <pr> --watch` returns the moment the checks settle.
+
+Use the `gh` CLI for every PR interaction (diff, comments, checks, runs). If no PR argument was given,
+ask which PR to work on, or infer it from the current branch (`gh pr view`).
+
+**A draft PR runs no CI** — every job is gated on `draft == false`, so no check ever reports and the CI stop
+condition can never be met. Check `gh pr view <pr> --json isDraft` first; if it is a draft, ask the user to
+run `gh pr ready <pr>`, or stop.
+
+## Review loop
+
+On every iteration, perform the following steps in order.
+
+### 1. Sync with the latest base branch
+
+- `git fetch origin main`. If `git rev-list --count HEAD..origin/main` is `0`, the branch is already current
+  — do not rebase.
+- Rebase only when behind **and** it matters: the PR conflicts (`gh pr view <pr> --json mergeable`), or CI
+  fails for something `main` has since fixed. A rebase rewrites history — it forces a force-push and
+  re-anchors every open review thread, so do not do it reflexively.
+- On any conflict whose resolution is not unambiguous, `git rebase --abort` and hand back to the user with
+  the conflicting files.
+
+### 2. Remove unrelated changes
+
+- Ensure the PR contains only changes related to its intended scope.
+- Remove accidental, generated, debugging, formatting-only, or otherwise unrelated modifications.
+
+### 3. Perform a comprehensive review
+
+Before reviewing, read and follow all project guidance:
+
+- `AGENTS.md` (root and any nested ones). The CI `codereview` gate treats `AGENTS.md` as the
+  authoritative standard, so stay consistent with it.
+- `CLAUDE.md` (root and any nested ones).
+- Any other repository-specific instructions, including the relevant docs under `docs/`.
+
+Review the PR as an experienced maintainer. Look for opportunities to improve: correctness, reliability,
+security, performance, architecture, maintainability, readability, simplicity, API design, error handling,
+edge cases, naming, and consistency with the existing codebase. Implement improvements wherever appropriate.
+
+### 4. Resolve GitHub review comments
+
+For every open review comment:
+
+- Review the feedback carefully.
+- Implement code changes where appropriate.
+- Reply with a concise explanation of the resolution (or the rationale if no change is required).
+- Resolve the conversation.
+
+### 5. Improve the code the PR touches
+
+Refactor to keep the codebase maintainable, but **only within the PR's existing footprint** — the lines and
+files it already changes. Do not rename a shared helper, restructure a neighbouring module, or tidy a
+function the PR never touched. Report such findings to the user at the end instead of fixing them.
+
+Judge the code against the Review Guidelines in `AGENTS.md` — comments, naming, function size, layering,
+encapsulation, reuse, module independence, business-logic placement, data access, and the frontend design
+system.
+
+### 6. Testing
+
+Every behavioural change carries its tests, and a PR that only adds tests is still a PR that must pass them.
+Follow the Testing Requirements in `AGENTS.md` — where tests live, the coverage target, BDD style, and the
+rule that only third-party APIs may be mocked.
+
+### 7. Fix CI failures
+
+Wait for the run with `gh pr checks <pr> --watch`, then drill into failures with `gh run view`.
+Fix the underlying issue rather than a superficial workaround. Continue until every check passes — treat them
+all as blocking, whether or not branch protection currently enforces them. GitHub renders these as
+`ci / <job>`; the CI jobs in this repo (`.github/workflows/ci.yml`) are:
+
+- **`ci / lint`** — `npm run lint` (ESLint on TS, remark on markdown, `mypy` strict + a `pylint`
+  cyclic-import check on Python) **and** `npm run fmt:check` (Prettier check + isort/black check). Format is
+  folded into this one job; there is no separate `format` check.
+- **`ci / test`** — integration tests in Docker via
+  `docker compose -f docker-compose.test.yml up --exit-code-from app`. It reports coverage against the
+  60/80 thresholds but does **not** fail on them (that step is `continue-on-error`), so a green `ci / test`
+  is no proof coverage held — a failing test is what turns it red.
+- **`ci / sonarqube`** — SonarQube quality gate (`needs: test`; consumes the coverage artifact). This is the
+  check that can actually block on coverage.
+- **`ci / codereview`** — the AI code-review gate (`anthropics/claude-code-action`, reading `AGENTS.md`).
+  It fails when it posts inline findings, so address/resolve every finding it raises.
+- **`ci / scan`** — Trivy (filesystem / IaC / Docker) and Checkov security scans; fails on HIGH/CRITICAL.
+
+Reproduce failures locally before pushing with `npm run lint`, `npm run fmt:check`, and `make run-test`
+(or `npm run test`).
+
+### 8. Commit progress
+
+After each meaningful batch of improvements:
+
+- Create a clear, descriptive commit using Conventional Commits (`<type>: <subject>`).
+- Push the PR's own feature branch. **Never push to `main`** (or any other base branch) — this loop
+  only ever commits to and pushes the branch under review.
+- After a rebase the push is a non-fast-forward: use `git push --force-with-lease`, never a bare `--force`.
+  A rejection means someone else pushed — stop for the user instead of overriding it.
+
+Then immediately begin another review iteration.
+
+## Stop conditions
+
+Continue looping until **all** of the following are true:
+
+- No unresolved GitHub review comments remain.
+- Every CI check on the PR is green.
+- A fresh review of the updated PR identifies no further significant improvements.
+
+Also stop and hand back to the user — with a short summary of what remains — if any of these trip,
+so the loop can never spin forever: an iteration produces no new commit (nothing left to improve);
+a change would revert or re-litigate an earlier iteration's work; the same check fails 3 times in a
+row; a rebase conflict is not unambiguous or a `--force-with-lease` push is rejected (the branch is
+contested); or you reach 10 iterations. When unsure whether an improvement is significant, prefer to stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 
 - Ensure MongoDB indexes cover every `find`, `find_one`, aggregation `$match`, or `sort` pattern.
 - Declare indexes in the repository layer (`internal/store/*_repository.py`).
+- A repository is pure storage. It inherits the CRUD verbs from `ApplicationRepository` (`modules/application/repository.py`); don't add `find_by_<field>` / `update_<field>` / `count_<thing>` methods — those belong on the module's reader or writer.
+- No MongoDB syntax crosses a repository's public surface. Callers pass a typed query object, never a `{"field": ...}` filter, an `ObjectId`, or a `$set`; every verb returns a domain dataclass, never a raw BSON document.
 
 #### 10. API Design
 
@@ -134,8 +136,9 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 
 #### 11. Business Logic Placement
 
-- Keep business rules in the service layer.
-- Avoid embedding domain logic inside Flask views or CLI scripts—delegate to services.
+- Keep business rules in the module, not in an execution layer. Avoid embedding domain logic inside Flask views, routers, workers, or CLI scripts—delegate to the module's service.
+- Service methods are thin: they call the right reader or writer. Logic needed only internally (password hashing, OTP generation, validation) lives in the module's `internal/*_writer.py` or `*_util.py`, not in the service itself.
+- Build a typed object from a request body with a `from_dict()`-style factory on the DTO (`types.py`), not with parsing code in the view.
 
 #### 12. Background Jobs
 
@@ -167,6 +170,8 @@ The frontend uses a token-driven design system. The full contract is in [Fronten
 - Never declare a `children` field in a Props interface or type. Type the component as `React.FC<PropsWithChildren<XProps>>`; for non-JSX content (a markdown string) use a named prop like `content`. Lint-enforced.
 - A component's public props must not accept a `className` escape hatch. className and Tailwind classes live inside components only.
 - Shared components and layout primitives live under `src/apps/frontend/components`, never in page folders.
+- Every component declares an optional `testId?: string` and renders it as `data-testid` on its root element, icons and decorative primitives included. Tests address the UI through stable `data-testid` hooks, never brittle text or class selectors.
+- Every component is accessible. An icon or shape that carries meaning exposes an accessible name (`ariaLabel` / `label`) and drops `aria-hidden`; a purely decorative glyph stays `aria-hidden`. An interactive element is a real semantic element (`button`, `a`, `input`) or carries the correct `role` plus keyboard handling. A form control associates its label and its error (`htmlFor` / `aria-describedby` / `aria-invalid`).
 
 #### 16. Data Fetching & State
 
@@ -194,6 +199,8 @@ The frontend uses a token-driven design system. The full contract is in [Fronten
 - Add or update pytest coverage for new backend endpoints or services (`tests/modules/...`).
 - Place integration tests alongside module directories under `tests/modules/<module>/`.
 - Target ≥60% coverage (80% preferred). Pytest runs with coverage reporting via `npm run test` or `make run-test`.
+- Write end-to-end, BDD-style tests that assert real system behaviour, not implementation details.
+- Mock third-party APIs only. Never mock internal services, domain objects, database access, or business logic — tests run against real MongoDB collections (see [Testing](docs/testing.md)).
 
 ## Commit and PR Guidelines
 
@@ -298,4 +305,5 @@ Choose your type carefully — it determines the label and semver impact.
 - [Configuration Guide](docs/configuration.md)
 - [MongoDB Security](docs/mongodb-security.md)
 - [Testing Guide](docs/testing.md)
+- [Skills](docs/skills.md)
 - [Engineering Handbook](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The template is not deployed to hosted environments. Run it locally per [Getting
 - [Scripts](docs/scripts.md)
 - [Code Formatting](docs/code-formatting.md)
 - [Workers](docs/workers.md)
+- [Skills](docs/skills.md)
 
 - [CI/CD](docs/deployment.md)
 - [DNS Setup](docs/dns-setup.md)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,23 @@
+# Skills
+
+This project ships [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) skills under
+`.claude/skills/`. A skill is a reusable, versioned prompt that lives with the codebase, so every
+contributor runs the same workflow. Invoke one in Claude Code by typing `/<skill-name>` and passing any
+arguments it expects.
+
+## Available skills
+
+| Skill                                                 | Invoke                             | What it does                                                    |
+| ----------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------- |
+| [Self-Review](../.claude/skills/self-review/SKILL.md) | `/self-review <PR link or number>` | Reviews and improves a PR in a loop until it is ready to merge. |
+
+## Self-Review
+
+After raising a PR, run the skill and pass the PR link or number:
+
+```
+/self-review <PR link or number>
+```
+
+The agent reviews the PR, applies improvements, resolves review comments, and fixes CI, looping until no
+significant improvements remain and every check is green. It never pushes to a base branch.


### PR DESCRIPTION
## Description

Adds a `self-review` Claude Code skill that an agent runs against an open PR to review and improve it in a loop — trimming out-of-scope changes, applying improvements within the PR's footprint, resolving GitHub review threads, and fixing CI — until every check is green and no significant improvements remain. The intent is to cut the manual round trips between raising a PR and it being merge-ready.

- **`.claude/skills/self-review/SKILL.md`** — the skill itself: an eight-step loop (sync base, trim unrelated changes, review, resolve review comments, refactor, tests, fix CI, commit) with explicit stop conditions so it cannot spin forever. Guardrails: it never pushes to `main` or any base branch, uses `--force-with-lease` over a bare `--force` and stops if the lease is rejected, aborts on any rebase conflict that isn't unambiguous, blocks on `gh pr checks --watch` rather than sleep-polling CI, and refuses to run against a draft PR — every CI job is gated on `draft == false`, so on a draft no check ever reports and the "all checks green" stop condition could never be met.
- **`docs/skills.md`** — what skills are, how to invoke them, and a table of what ships in this repo. Linked from the README doc index and from AGENTS.md.
- **`AGENTS.md`** — extends the review guidelines so the `ci / codereview` gate enforces conventions that until now only lived in CLAUDE.md: repository purity (CRUD verbs are inherited from `ApplicationRepository`; no Mongo syntax crosses a repository's public surface), business-logic placement (thin services, `from_dict()` factories on DTOs rather than parsing in views), the frontend `testId` and accessibility requirements, and the testing rules (BDD style, third-party APIs are the only thing that may be mocked).

No application code is touched, so there is no runtime or behavioural change.

Discussed in this [Team Engineering thread](https://teams.cloud.microsoft/l/message/19:HE0T-hXTMG-3sZdg0pBN1IOMnocfZaeeH8SymCTDKiw1@thread.tacv2/1783568492737?tenantId=79836b2a-53cc-4854-81b4-ba2d7c9f2726&groupId=76c0380b-15c1-4a18-8308-24c4abc83332&parentMessageId=1783568492737&teamName=Better&channelName=Team%20Engineering&createdTime=1783568492737&ngc=true).

## Database schema changes

No database schema changes.

## Tests

### Automated test cases added

No automated tests added — the PR adds markdown only (a skill prompt and documentation) and has no runtime surface to test.

### Manual test cases run

* Confirmed Claude Code discovers the new skill: after adding `.claude/skills/self-review/SKILL.md`, `self-review` is listed as an available skill and is invocable as `/self-review <PR link or number>`.
* Ran `npx prettier --check` over all four changed markdown files — the same check `ci / lint` runs via `npm run fmt:check`. All pass.
* Cross-checked every CI claim the skill makes against `.github/workflows/ci.yml`, since the skill instructs an agent to act on them: the five `ci / <job>` names, `sonarqube`'s `needs: test` dependency on the coverage artifact, the coverage-threshold step being `continue-on-error` (so a green `ci / test` is no proof coverage held), and `ci / scan` being Trivy plus Checkov failing on HIGH/CRITICAL. All accurate.
* Verified every cross-reference resolves: the skill's pointers to the "Review Guidelines" and "Testing Requirements" headings in `AGENTS.md`, and the new `docs/skills.md` links from both `README.md` and `AGENTS.md`.

Manual Testing Video: https://www.loom.com/share/fb9b5f35786944258b19c61643a2e052