### PR TITLE
chore: add pr-conventions and pr-review-loop skills

### DIFF
--- a/.claude/skills/pr-conventions/SKILL.md
+++ b/.claude/skills/pr-conventions/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr-conventions
+description: How to write a pull request for this repo — title format and a plain-English description that builds context. Use whenever opening a PR or editing a PR title/body.
+---
+
+# Writing a pull request
+
+Follow this whenever you open a PR or update its title/description.
+
+## Title
+
+Use a Conventional Commit prefix followed by a short, human-friendly summary:
+
+```
+<type>(<optional scope>): <summary>
+```
+
+- Pick the `<type>` from the table in [AGENTS.md](../../../AGENTS.md#auto-labeling)
+  (`feat`, `fix`, `perf`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `revert`).
+  The prefix drives auto-labeling and semver, so choose it deliberately.
+- The summary reads like a sentence a teammate would understand, not a restatement of the type.
+  Good: `refactor: make login email-only and drop phone/OTP`. Bad: `refactor: changes`.
+
+## Description
+
+Write for a reader who does **not** have the background to this change. Build the context first,
+then explain the change. Use plain English. Do not restate the task or the instructions you were
+given — describe the work as if documenting it for the team.
+
+Include, in this order (skip a part only when it genuinely does not apply):
+
+1. **Context** — what the reader needs to know to understand the change: what this part of the
+   system does today, and what problem or gap prompted the change. Write it so someone new to the
+   feature can follow. Do not label this "Background" or quote the request; just set the scene in
+   plain terms.
+2. **What this changes** — the fix or feature, described at a behaviour level.
+3. **Alternatives considered** — only if there were real alternatives worth weighing. Name the main
+   one and say why it was not chosen. Skip this section entirely if there was no meaningful choice.
+4. **How it works** — the high-level technical approach. Describe the flow and the key pieces, not a
+   file-by-file diff. Where a flow has several steps or actors, include a sequence diagram (Mermaid
+   `sequenceDiagram`) or a small ASCII diagram to make it concrete.
+5. **Demo** — if a preview/demo link exists (e.g. the deploy bot posted a preview URL), include it.
+
+Keep the writing tight and specific. No filler, no marketing tone, no emoji.
+
+## Do not
+
+- Do not paste your prompt, task description, or these instructions into the PR body.
+- Do not write a file-by-file changelog in place of an explanation of the approach.
+- Do not leave the description empty or write only "see title".
+
+## After opening or updating a PR
+
+Start the continuous review loop for the PR — see [pr-review-loop](../pr-review-loop/SKILL.md).
+Every raise of a PR and every push to it should be followed by the review loop.

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -5,93 +5,167 @@ description: Continuously review and improve a pull request until CI is green, a
 
 # PR review loop
 
-Start a dedicated background agent that continuously reviews and improves a pull request until
-**all** stop conditions are met. Kick this off automatically after you open a PR and after every
-push to it.
+Start a dedicated background AI agent that continuously reviews and improves this pull request until
+**all** of the following conditions are met:
 
-**Do not sleep or add delays between iterations.** GitHub comments and CI results arrive quickly;
-poll and react as soon as new information is available. Begin the next iteration immediately after
-each push.
-
-## Stop conditions
-
-Keep looping until **all** of these are true:
-
-- A fresh review of the updated PR finds no further significant improvements.
-- No unresolved GitHub review comments remain.
+- No significant improvements are identified during the latest review.
+- There are no unresolved GitHub review comments.
 - All required CI checks are passing.
 
-## Each iteration
+The agent should immediately begin another iteration after every push. **Do not sleep or introduce
+delays** between iterations. GitHub comments and CI results often arrive quickly, so continuously
+poll and react as soon as new information is available.
 
-### 1. Sync with the base branch
+Kick this off automatically after you open a PR and after every push to it.
 
-Rebase onto the latest base branch, resolve conflicts, and make sure the branch is up to date
-before reviewing.
+## Review loop
+
+On every iteration, perform the following steps.
+
+### 1. Sync with the latest base branch
+
+- Rebase onto the latest base branch.
+- Resolve any merge conflicts.
+- Ensure the branch is up to date before reviewing.
 
 ### 2. Remove unrelated changes
 
-Read the linked issue (if any) to understand the intended scope. Keep the PR to that scope only.
-Strip accidental, generated, debugging, or formatting-only changes that are not part of the PR's
-purpose.
+- Review the associated issue/ticket, if applicable, to understand the scope of work.
+- Ensure the PR contains only changes related to its intended scope.
+- Remove accidental, generated, debugging, formatting-only, or otherwise unrelated modifications.
 
-### 3. Comprehensive review
+### 3. Perform a comprehensive review
 
-First read and follow all project guidance: `CLAUDE.md`, `AGENTS.md`, and any other repo-specific
-instructions. Then review as an experienced maintainer, looking for improvements to: correctness,
-reliability, security, performance, architecture, maintainability, readability, simplicity, API
-design, error handling, edge cases, naming, and consistency with the existing codebase. Implement
-improvements where appropriate.
+Before reviewing, read and follow all project guidance, including:
 
-### 4. Resolve review comments
+- `CLAUDE.md`
+- `AGENTS.md`
+- skills
+- Any other repository-specific instructions
 
-For every open review comment: consider it carefully, make code changes where appropriate, reply
-with a concise explanation of the resolution (or the rationale if no change is needed), and resolve
-the conversation.
+Review the PR as if you are an experienced maintainer.
+
+Look for opportunities to improve:
+
+- Correctness
+- Reliability
+- Security
+- Performance
+- Architecture
+- Maintainability
+- Readability
+- Simplicity
+- API design
+- Error handling
+- Edge cases
+- Naming
+- Consistency with the existing codebase
+
+Implement improvements wherever appropriate.
+
+### 4. Resolve GitHub review comments
+
+For every open review comment:
+
+- Review the feedback carefully.
+- Implement code changes where appropriate.
+- Reply with a concise explanation of the resolution (or rationale if no change is required).
+- Resolve the conversation.
 
 ### 5. Improve the codebase
 
 Refactor where appropriate to keep the codebase maintainable.
 
-**Business logic** should **never** live inside execution layers such as views, controllers,
-workers, jobs, CLI commands, or HTTP handlers. Execution layers orchestrate work only. Business
-logic belongs inside appropriate domain objects such as readers, writers, domain models, data
-classes, and services. For example, if a request body is received as a dictionary, converting that
-dictionary into a typed object should be implemented as something like `MyType.from_dict()` rather
-than inside the view.
+#### Business logic
 
-**Prefer object-oriented modelling.** Discourage large procedural or functional implementations.
-When solving a problem: pause and identify the entities involved, model the state each entity owns,
-model the behaviour that belongs to that entity, and apply first-principles thinking instead of
-writing long functions. Small helper functions are acceptable, but avoid long functions performing
-many unrelated responsibilities. Optimize for code that is easy for someone completely new to the
-codebase to understand.
+Business logic should **never** live inside execution layers such as:
+
+- Views
+- Controllers
+- Workers
+- Jobs
+- CLI commands
+- HTTP handlers
+
+Execution layers should orchestrate work only.
+
+Business logic should instead live inside appropriate domain objects such as:
+
+- Readers
+- Writers
+- Domain models
+- Data classes
+- Services
+
+For example, if a request body is received as a dictionary, converting that dictionary into a typed
+object should be implemented as something like `MyType.from_dict()` rather than inside the view.
+
+#### Prefer object-oriented modelling
+
+Discourage large procedural or functional implementations.
+
+When solving a problem:
+
+- Pause and identify the entities involved.
+- Model the state each entity owns.
+- Model the behaviour that belongs to that entity.
+- Apply first-principles thinking instead of writing long functions.
+
+Small helper functions are acceptable, but avoid long functions performing many unrelated
+responsibilities.
+
+Optimize for code that is easy for someone completely new to the codebase to understand.
 
 ### 6. Code comments
 
-No new code comments. (If a genuinely non-obvious invariant or workaround already carries a "why"
-comment, leave it; but do not add new ones.)
+No new code comments.
 
 ### 7. Testing philosophy
 
-Tests should be written in an end-to-end, BDD style wherever practical. Only mock **third-party
-APIs**. Do **not** mock internal services, domain objects, database access, or business logic. Tests
-should validate the real behaviour of the system rather than implementation details.
+Tests should be written in an end-to-end, BDD style wherever practical.
 
-If a frontend test setup is present (`src/apps/frontend/vitest.config.ts`), any change under
-`src/apps/frontend` that adds or changes behaviour ships a colocated `*.test.tsx` (purely visual
-markup does not). `axios` and browser navigation are the only permitted mocks — never `vi.mock` a
-module under `frontend/`, which stubs out the code under test and leaves the suite green while the
-behaviour is broken. See `docs/testing.md`.
+Only mock **third-party APIs**.
 
-### 8. Fix CI
+Do **not** mock:
 
-Investigate every failing CI job and fix the underlying cause, not a superficial workaround.
-Continue until every required check passes.
+- Internal services
+- Domain objects
+- Database access
+- Business logic
 
-### 9. Commit and continue
+Tests should validate the real behaviour of the system rather than implementation details.
 
-After each meaningful batch of improvements, make a clear, descriptive commit and push. Then begin
-the next iteration immediately.
+For the frontend, this is a requirement where a frontend test setup is present
+(`src/apps/frontend/vitest.config.ts`): any change under `src/apps/frontend` that adds or changes
+behaviour ships a colocated `*.test.tsx` (purely visual markup does not). `axios` and browser
+navigation are the only permitted mocks — never `vi.mock` a module under `frontend/`, which stubs
+out the code under test and leaves the suite green while the behaviour is broken. See
+`docs/testing.md`.
+
+### 8. Fix CI failures
+
+Investigate every failing CI job.
+
+Fix the underlying issue rather than applying superficial workarounds.
+
+Continue until every required check is passing.
+
+### 9. Commit progress
+
+After each meaningful batch of improvements:
+
+- Create a clear, descriptive commit.
+- Push the branch.
+
+Immediately begin another review iteration.
+
+## Stop conditions
+
+Continue looping until **all** of the following are true:
+
+- No unresolved GitHub review comments remain.
+- All required CI checks are passing.
+- A fresh review of the updated PR identifies no further significant improvements.
 
 ## Relationship to pr-conventions
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -48,29 +48,34 @@ For every open review comment: consider it carefully, make code changes where ap
 with a concise explanation of the resolution (or the rationale if no change is needed), and resolve
 the conversation.
 
-### 5. Keep the codebase clean
+### 5. Improve the codebase
 
-**Business logic never lives in execution layers** (views, controllers, workers, jobs, CLI
-commands, HTTP handlers). Those orchestrate only. Business logic belongs in domain objects —
-readers, writers, domain models, data classes, services. Example: turning a request-body dict into
-a typed object is `MyType.from_dict()`, not inline in the view.
+Refactor where appropriate to keep the codebase maintainable.
 
-**Prefer object-oriented modelling** over large procedural or functional code. Identify the entities
-involved, model the state each owns and the behaviour that belongs to it, and think from first
-principles. Small helper functions are fine; long functions doing many unrelated things are not.
-Optimize for code a newcomer can understand.
+**Business logic** should **never** live inside execution layers such as views, controllers,
+workers, jobs, CLI commands, or HTTP handlers. Execution layers orchestrate work only. Business
+logic belongs inside appropriate domain objects such as readers, writers, domain models, data
+classes, and services. For example, if a request body is received as a dictionary, converting that
+dictionary into a typed object should be implemented as something like `MyType.from_dict()` rather
+than inside the view.
 
-### 6. Comments
+**Prefer object-oriented modelling.** Discourage large procedural or functional implementations.
+When solving a problem: pause and identify the entities involved, model the state each entity owns,
+model the behaviour that belongs to that entity, and apply first-principles thinking instead of
+writing long functions. Small helper functions are acceptable, but avoid long functions performing
+many unrelated responsibilities. Optimize for code that is easy for someone completely new to the
+codebase to understand.
 
-No new code comments. Code should be self-explanatory through naming and structure. Remove comments
-that narrate what the next line does. (If a genuinely non-obvious invariant or workaround already
-carries a "why" comment, leave it; but do not add new ones.)
+### 6. Code comments
 
-### 7. Tests
+No new code comments. (If a genuinely non-obvious invariant or workaround already carries a "why"
+comment, leave it; but do not add new ones.)
 
-Write end-to-end, BDD-style tests wherever practical. Mock **only third-party APIs**. Do not mock
-internal services, domain objects, database access, or business logic. Tests validate real system
-behaviour, not implementation details.
+### 7. Testing philosophy
+
+Tests should be written in an end-to-end, BDD style wherever practical. Only mock **third-party
+APIs**. Do **not** mock internal services, domain objects, database access, or business logic. Tests
+should validate the real behaviour of the system rather than implementation details.
 
 If a frontend test setup is present (`src/apps/frontend/vitest.config.ts`), any change under
 `src/apps/frontend` that adds or changes behaviour ships a colocated `*.test.tsx` (purely visual

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -167,6 +167,52 @@ Continue looping until **all** of the following are true:
 - All required CI checks are passing.
 - A fresh review of the updated PR identifies no further significant improvements.
 
+## Operational notes
+
+Follow the loop above; these are the mechanics that make each step actually work with GitHub and CI.
+
+- **Never `sleep`-and-poll for CI.** Block on the result instead: `gh pr checks <pr> --watch` returns the
+  moment the checks settle. Then drill into failures with `gh run view`.
+- **A draft PR runs no CI** — every job is gated on `draft == false`, so no check ever reports and the
+  "all checks green" stop condition can never be met. Check `gh pr view <pr> --json isDraft` first; if it is
+  a draft, ask the user to run `gh pr ready <pr>`, or stop.
+- **Whether a review thread is resolved is a GraphQL-only fact.** The REST payload behind
+  `gh pr view --json comments` carries no resolution state, so read threads through `reviewThreads`, and
+  reply/resolve with the thread id (`PRRT_…`) it returns — stay on GraphQL for the whole step:
+
+  ```bash
+  # list unresolved threads
+  gh api graphql -f query='
+    query($owner:String!, $repo:String!, $pr:Int!) {
+      repository(owner:$owner, name:$repo) { pullRequest(number:$pr) {
+        reviewThreads(first:100) { nodes {
+          id isResolved
+          comments(first:10) { nodes { path line body author { login } } }
+        } }
+      } }
+    }' -f owner=<owner> -f repo=<repo> -F pr=<pr> \
+    --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)'
+
+  # reply, then resolve, using the thread id above
+  gh api graphql -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{url}}}' -f t=<thread-id> -f b='<reply>'
+  gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<thread-id>
+  ```
+
+  Resolve only threads you have actually addressed — never blanket-resolve to clear the stop condition.
+- **Rebase only when it matters** — the PR conflicts or CI fails for something `main` has since fixed. A
+  rebase rewrites history, forces a push, and re-anchors every open review thread, so do not do it
+  reflexively. On any conflict whose resolution is not unambiguous, `git rebase --abort` and hand back.
+- **Pushing after a rebase** is a non-fast-forward: use `git push --force-with-lease`, never a bare
+  `--force`. A rejection means someone else pushed — stop for the user. **Never push to `main`** or any base
+  branch; this loop only ever pushes the branch under review.
+- **The `label` check** (`pr-labeler.yml`) derives type/semver labels from the PR title and fails when the
+  title is not Conventional Commits. It is the one check no commit can fix — repair it with
+  `gh pr edit <pr> --title '<type>: <subject>'`, not by pushing code.
+- **Never let the loop spin forever.** Stop and hand back to the user with a short summary of what remains if:
+  an iteration produces no new commit; a change would revert an earlier iteration; the same check fails 3
+  times in a row; a rebase conflict is not unambiguous or a `--force-with-lease` push is rejected; or you
+  reach 10 iterations. When unsure whether an improvement is significant, prefer to stop.
+
 ## Relationship to pr-conventions
 
 This loop assumes the PR title and description already follow [pr-conventions](../pr-conventions/SKILL.md).

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -199,6 +199,7 @@ Follow the loop above; these are the mechanics that make each step actually work
   ```
 
   Resolve only threads you have actually addressed — never blanket-resolve to clear the stop condition.
+
 - **Rebase only when it matters** — the PR conflicts or CI fails for something `main` has since fixed. A
   rebase rewrites history, forces a push, and re-anchors every open review thread, so do not do it
   reflexively. On any conflict whose resolution is not unambiguous, `git rebase --abort` and hand back.

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -30,8 +30,9 @@ before reviewing.
 
 ### 2. Remove unrelated changes
 
-Keep the PR to its intended scope only. Strip accidental, generated, debugging, or formatting-only
-changes that are not part of the PR's purpose.
+Read the linked issue (if any) to understand the intended scope. Keep the PR to that scope only.
+Strip accidental, generated, debugging, or formatting-only changes that are not part of the PR's
+purpose.
 
 ### 3. Comprehensive review
 
@@ -61,9 +62,9 @@ Optimize for code a newcomer can understand.
 
 ### 6. Comments
 
-Use comments sparingly; code should be self-explanatory. Remove comments that just narrate what the
-next line does. Keep or add comments only for things that are hard to infer: why a decision was
-made, business rules, trade-offs, invariants, assumptions, non-obvious workflows.
+No new code comments. Code should be self-explanatory through naming and structure. Remove comments
+that narrate what the next line does. (If a genuinely non-obvious invariant or workaround already
+carries a "why" comment, leave it; but do not add new ones.)
 
 ### 7. Tests
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pr-review-loop
+description: Continuously review and improve a pull request until CI is green, all review comments are resolved, and no further improvements remain. Start this after opening a PR or pushing to one.
+---
+
+# PR review loop
+
+Start a dedicated background agent that continuously reviews and improves a pull request until
+**all** stop conditions are met. Kick this off automatically after you open a PR and after every
+push to it.
+
+**Do not sleep or add delays between iterations.** GitHub comments and CI results arrive quickly;
+poll and react as soon as new information is available. Begin the next iteration immediately after
+each push.
+
+## Stop conditions
+
+Keep looping until **all** of these are true:
+
+- A fresh review of the updated PR finds no further significant improvements.
+- No unresolved GitHub review comments remain.
+- All required CI checks are passing.
+
+## Each iteration
+
+### 1. Sync with the base branch
+
+Rebase onto the latest base branch, resolve conflicts, and make sure the branch is up to date
+before reviewing.
+
+### 2. Remove unrelated changes
+
+Keep the PR to its intended scope only. Strip accidental, generated, debugging, or formatting-only
+changes that are not part of the PR's purpose.
+
+### 3. Comprehensive review
+
+First read and follow all project guidance: `CLAUDE.md`, `AGENTS.md`, and any other repo-specific
+instructions. Then review as an experienced maintainer, looking for improvements to: correctness,
+reliability, security, performance, architecture, maintainability, readability, simplicity, API
+design, error handling, edge cases, naming, and consistency with the existing codebase. Implement
+improvements where appropriate.
+
+### 4. Resolve review comments
+
+For every open review comment: consider it carefully, make code changes where appropriate, reply
+with a concise explanation of the resolution (or the rationale if no change is needed), and resolve
+the conversation.
+
+### 5. Keep the codebase clean
+
+**Business logic never lives in execution layers** (views, controllers, workers, jobs, CLI
+commands, HTTP handlers). Those orchestrate only. Business logic belongs in domain objects —
+readers, writers, domain models, data classes, services. Example: turning a request-body dict into
+a typed object is `MyType.from_dict()`, not inline in the view.
+
+**Prefer object-oriented modelling** over large procedural or functional code. Identify the entities
+involved, model the state each owns and the behaviour that belongs to it, and think from first
+principles. Small helper functions are fine; long functions doing many unrelated things are not.
+Optimize for code a newcomer can understand.
+
+### 6. Comments
+
+Use comments sparingly; code should be self-explanatory. Remove comments that just narrate what the
+next line does. Keep or add comments only for things that are hard to infer: why a decision was
+made, business rules, trade-offs, invariants, assumptions, non-obvious workflows.
+
+### 7. Tests
+
+Write end-to-end, BDD-style tests wherever practical. Mock **only third-party APIs**. Do not mock
+internal services, domain objects, database access, or business logic. Tests validate real system
+behaviour, not implementation details.
+
+If a frontend test setup is present (`src/apps/frontend/vitest.config.ts`), any change under
+`src/apps/frontend` that adds or changes behaviour ships a colocated `*.test.tsx` (purely visual
+markup does not). `axios` and browser navigation are the only permitted mocks — never `vi.mock` a
+module under `frontend/`, which stubs out the code under test and leaves the suite green while the
+behaviour is broken. See `docs/testing.md`.
+
+### 8. Fix CI
+
+Investigate every failing CI job and fix the underlying cause, not a superficial workaround.
+Continue until every required check passes.
+
+### 9. Commit and continue
+
+After each meaningful batch of improvements, make a clear, descriptive commit and push. Then begin
+the next iteration immediately.
+
+## Relationship to pr-conventions
+
+This loop assumes the PR title and description already follow [pr-conventions](../pr-conventions/SKILL.md).
+If the description drifts from the actual change during the loop, update it to match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,8 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 
 - Ensure MongoDB indexes cover every `find`, `find_one`, aggregation `$match`, or `sort` pattern.
 - Declare indexes in the repository layer (`internal/store/*_repository.py`).
+- A repository is pure storage. It inherits the CRUD verbs from `ApplicationRepository` (`modules/application/repository.py`); don't add `find_by_<field>` / `update_<field>` / `count_<thing>` methods—those belong on the module's reader or writer.
+- No MongoDB syntax crosses a repository's public surface. Callers pass a typed query object, never a `{"field": ...}` filter, an `ObjectId`, or a `$set`; every verb returns a domain dataclass, never a raw BSON document.
 
 #### 10. API Design
 
@@ -134,8 +136,9 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 
 #### 11. Business Logic Placement
 
-- Keep business rules in the service layer.
-- Avoid embedding domain logic inside Flask views or CLI scripts—delegate to services.
+- Keep business rules in the module, not in an execution layer. Avoid embedding domain logic inside Flask views, routers, workers, or CLI scripts—delegate to the module's service.
+- Service methods are thin: they call the right reader or writer. Logic needed only internally (password hashing, OTP generation, validation) lives in the module's `internal/*_writer.py` or `*_util.py`, not in the service itself.
+- Build a typed object from a request body with a `from_dict()`-style factory on the DTO (`types.py`), not with parsing code in the view.
 
 #### 12. Background Jobs
 
@@ -167,6 +170,8 @@ The frontend uses a token-driven design system. The full contract is in [Fronten
 - Never declare a `children` field in a Props interface or type. Type the component as `React.FC<PropsWithChildren<XProps>>`; for non-JSX content (a markdown string) use a named prop like `content`. Lint-enforced.
 - A component's public props must not accept a `className` escape hatch. className and Tailwind classes live inside components only.
 - Shared components and layout primitives live under `src/apps/frontend/components`, never in page folders.
+- Every component declares an optional `testId?: string` and renders it as `data-testid` on its root element, icons and decorative primitives included. Tests address the UI through stable `data-testid` hooks, never brittle text or class selectors.
+- Every component is accessible. An icon or shape that carries meaning exposes an accessible name (`ariaLabel` / `label`) and drops `aria-hidden`; a purely decorative glyph stays `aria-hidden`. An interactive element is a real semantic element (`button`, `a`, `input`) or carries the correct `role` plus keyboard handling. A form control associates its label and its error (`htmlFor` / `aria-describedby` / `aria-invalid`).
 
 #### 16. Data Fetching & State
 


### PR DESCRIPTION
## Context

The backend and frontend guidelines already live in `AGENTS.md` and `CLAUDE.md`, and the CI review action reads them on every PR. What was missing is the workflow guidance our other repos (operate, borderless) carry as Claude Code "skills": how to write a PR for this repo, and how to keep reviewing it until it is actually merge-ready. Without them, each contributor (human or agent) reinvents the PR title/description format, and there is no shared definition of "done" for a PR.

This also consolidates the work from the closed self-review PR (#708) so there is one review-loop skill, not two competing ones.

## What this changes

Adds two skills under `.claude/skills/`:

- **pr-conventions** — the PR title format (conventional-commit prefix that drives auto-labeling and semver) and a plain-English description structure (context first, then the change, how it works, demo). Points at the existing `AGENTS.md#auto-labeling` table.
- **pr-review-loop** — the continuous review loop we run by hand: a dedicated background agent that syncs with base, strips out-of-scope changes, reviews as a maintainer against `AGENTS.md`/`CLAUDE.md`, resolves every review comment, keeps business logic out of execution layers, writes BDD tests that mock only third-party APIs, adds no new code comments, fixes CI at the root, and loops with no delays until CI is green and no comments or improvements remain.

Carries over from #708:
- The review-loop's operational mechanics: watch CI (`gh pr checks --watch`) instead of sleep-polling, resolve review threads via the GraphQL `reviewThreads` API (REST cannot read resolution state), draft-PR gating, `--force-with-lease`, and a loop guard that stops after 10 iterations or a contested push.
- The AGENTS.md review guidelines it added: repository purity (CRUD inherited from `ApplicationRepository`, no Mongo syntax on a repository's public surface), thin services with `from_dict()` factories on DTOs, and the frontend `testId` + accessibility requirements.

No application code changes.

## How it works

These are documentation-only files. Any Claude Code session in this repo picks up the skills automatically; a contributor invokes them by name when opening or reviewing a PR.

One adaptation from the source repos: the review loop's frontend-test requirement activates only when a Vitest config (`src/apps/frontend/vitest.config.ts`) is present, so the rule stays accurate today and turns on by itself once the frontend test setup lands.
