### PR TITLE
fix(config): unset __name env-var mapping blanks the base config value

### DIFF
--- a/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
+++ b/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
@@ -26,7 +26,9 @@ class CustomEnvConfig:
 
         for key, value in data.items():
             if isinstance(value, dict):
-                updated_data[key] = CustomEnvConfig._search_and_replace_dict_value_with_env(value)
+                result = CustomEnvConfig._search_and_replace_dict_value_with_env(value)
+                if result is not None:
+                    updated_data[key] = result
             elif isinstance(value, str):
                 result = ConfigUtil.read_value_from_file(f"{CustomEnvConfig.SECRETS_DIR}/{value}")
                 if result is not None:

--- a/tests/modules/config/test_custom_env_config.py
+++ b/tests/modules/config/test_custom_env_config.py
@@ -1,0 +1,46 @@
+import os
+from typing import Any
+
+from modules.config.internals.config_files.custom_env_config_file import CustomEnvConfig
+from modules.config.internals.config_utils import ConfigUtil
+from tests.modules.config.base_test_config import BaseTestConfig
+
+
+class TestCustomEnvConfig(BaseTestConfig):
+    UNSET_ENV_VAR = "FLASK_REACT_TEMPLATE_TEST_UNSET_ENV_VAR"
+
+    def setup_method(self, method: Any) -> None:
+        super().setup_method(method)
+        os.environ.pop(self.UNSET_ENV_VAR, None)
+
+    def test_unset_name_mapping_omits_key(self) -> None:
+        overrides = CustomEnvConfig._apply_environment_overrides({"feature": {"__name": self.UNSET_ENV_VAR}})
+        assert "feature" not in overrides
+
+    def test_unset_name_mapping_does_not_blank_base_value(self) -> None:
+        base_layer = {"feature": {"enabled": True}}
+        override_layer = CustomEnvConfig._apply_environment_overrides({"feature": {"__name": self.UNSET_ENV_VAR}})
+
+        merged = ConfigUtil.deep_merge(base_layer, override_layer)
+
+        assert merged["feature"] == {"enabled": True}
+
+    def test_set_name_mapping_overrides_base_value(self) -> None:
+        os.environ[self.UNSET_ENV_VAR] = "from-env"
+        try:
+            overrides = CustomEnvConfig._apply_environment_overrides({"feature": {"__name": self.UNSET_ENV_VAR}})
+        finally:
+            os.environ.pop(self.UNSET_ENV_VAR, None)
+
+        assert overrides["feature"] == "from-env"
+
+    def test_nested_dict_without_name_still_merges(self) -> None:
+        os.environ[self.UNSET_ENV_VAR] = "child-value"
+        try:
+            overrides = CustomEnvConfig._apply_environment_overrides(
+                {"parent": {"child": {"__name": self.UNSET_ENV_VAR}}}
+            )
+        finally:
+            os.environ.pop(self.UNSET_ENV_VAR, None)
+
+        assert overrides["parent"] == {"child": "child-value"}


### PR DESCRIPTION
## Context

Backend config is assembled from three layers merged in order: `default.yml`, the app-env file (`development.yml`, `testing.yml`, ...), and finally the custom-environment-variables layer, which reads values from environment variables and wins over the files below it.

That last layer supports two mapping styles for a key: a plain string naming an env var, and a `{ __name: SOME_ENV_VAR }` object (which also allows `__format` for typed values). When the named env var is unset, the mapping resolves to `None`.

The plain-string branch already guards this: it only writes the key into the override when the env var actually produced a value. The `__name`-object branch did not. It wrote the key unconditionally, so an unset env var wrote `None` into the winning layer and blanked whatever a base file had set for that key.

## Why it matters

This is environment-specific and silent. A value correctly set in a base config file reads as missing on any machine where the mapped env var happens to be unset, and features keyed off it quietly no-op. It typically bites locally, where fewer env vars are set, while cloud looks fine because a secrets manager sets them, so it is easy to misdiagnose as an app bug rather than a config-loading bug.

## What this changes

In the dict branch of `_apply_environment_overrides`, the resolved value is assigned only when it is not `None`, exactly as the string branch already does. An unset `__name` mapping now omits the key from the override layer instead of setting it to `None`, so the base value survives the merge. Nested non-`__name` dicts always resolve to a dict, so they keep merging as before; only the `None` case is skipped.

## How it works

The override layer is a plain dict handed to `deep_merge(default, app_env, custom_env)`. `deep_merge` lets a later layer's value overwrite an earlier one. Previously the override carried `key: None`, which overwrote the base value. Now the key is simply absent from the override, so `deep_merge` leaves the base layer's value in place.

## Tests

Added `tests/modules/config/test_custom_env_config.py`:

- an unset `__name` mapping omits the key from the override,
- merging that override over a base layer keeps the base value,
- a set `__name` mapping still overrides the base value,
- a nested non-`__name` dict still merges.

Verified the tests fail against the pre-fix code (`{'feature': None}`) and pass with the fix. Full backend suite green locally (202 passed) against Mongo + Redis; lint (mypy, pylint), isort and black checks pass on the changed files.

Closes #715