### PR TITLE
fix(deps): clear Trivy HIGH/CRITICAL CVEs (axios, tar, js-yaml, fast-uri, shell-quote, brace-expansion)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,6 @@
 # This file lists CVEs to ignore in Trivy scans
 # Only add CVEs here when they cannot be fixed and have been reviewed for risk
 
-# minimatch@10.2.2 in npm's bundled dependencies
-# - npm@11.11.0 (latest) bundles minimatch@10.2.2, fix requires 10.2.3+
-# - npm@10.9.5 has minimatch@9.0.9 (patched) but has unpatched tar@6.2.1
-# - No npm version currently has all dependencies patched
-# - These are DoS vulnerabilities via crafted glob patterns, low risk for CI
-# Reviewed: 2026-03-04
-CVE-2026-27903
-CVE-2026-27904
-
 # picomatch@2.3.1 / picomatch@4.0.3 — transitive via tailwindcss (prod) and eslint tooling (dev)
 # - CVE is a ReDoS via crafted extglob patterns in glob matching
 # - No version of picomatch satisfies all requiring packages simultaneously without
@@ -17,21 +8,6 @@ CVE-2026-27904
 # - Risk is low: picomatch is used for CSS class detection, not for processing user input
 # Reviewed: 2026-04-01
 CVE-2026-33671
-
-# tar@7.5.9 in npm's bundled dependencies
-# - npm@11.11.0 bundles tar@^7.5.9; fixes require 7.5.10+
-# - No newer npm release currently available in this setup with patched tar
-# Reviewed: 2026-03-11
-CVE-2026-29786
-CVE-2026-31802
-
-# axios@1.13.5 in Node.js dependencies
-# - CVE-2025-62718: SSRF and proxy bypass via improper hostname normalization
-# - CVE-2026-40175: SSRF and proxy bypass (same root cause, follow-on advisory)
-# - Fix available in axios@1.15.0; upgrade blocked pending compatibility testing
-# Reviewed: 2026-04-13
-CVE-2025-62718
-CVE-2026-40175
 
 # CVE-2026-48815 — temporarily suppressed 2026-07-08 to unblock CI; risk review pending
 CVE-2026-48815

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ FROM node:22-alpine AS node-builder
 WORKDIR /build
 
 # Upgrade npm to fix bundled dependency vulnerabilities (glob, minimatch, tar CVEs)
-RUN npm install -g npm@11.11.0
+RUN npm install -g npm@12.0.1
 
 # Copy package files first for better layer caching
 COPY package.json package-lock.json ./
@@ -77,7 +77,7 @@ RUN apt-get update -y && \
         jq \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    npm install -g npm@11.11.0 && \
+    npm install -g npm@12.0.1 && \
     apt-get remove -y curl && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2707,9 +2707,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5915,9 +5915,9 @@
       }
     },
     "node_modules/cpx/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -7196,9 +7196,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7338,9 +7338,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8258,9 +8258,9 @@
       }
     },
     "node_modules/forever-monitor/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8670,9 +8670,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -16425,9 +16425,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@datadog/browser-rum": "^6.6.4",
         "@datadog/browser-rum-react": "^6.6.4",
         "autoprefixer": "^10.4.18",
-        "axios": "^1.13.5",
+        "axios": "^1.18.0",
         "clsx": "^2.1.0",
         "config": "^3.3.7",
         "cors": "^2.8.5",
@@ -62,7 +62,7 @@
         "forever": "^4.0.3",
         "html-webpack-plugin": "^5.5.0",
         "husky": "^9.1.4",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "lint-staged": "^15.4.1",
         "nyc": "^15.1.0",
         "remark-cli": "^10.0.0",
@@ -2642,6 +2642,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
       "license": "MIT",
@@ -2650,7 +2660,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2682,6 +2694,16 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
@@ -2806,7 +2828,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3771,9 +3795,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4738,9 +4762,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -4910,14 +4934,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -5886,6 +5902,16 @@
       },
       "bin": {
         "cpx": "bin/index.js"
+      }
+    },
+    "node_modules/cpx/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/cpx/node_modules/minimatch": {
@@ -7139,6 +7165,17 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "dev": true,
@@ -7253,6 +7290,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "license": "Apache-2.0",
@@ -7278,7 +7325,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7647,9 +7696,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.0.0.tgz",
-      "integrity": "sha512-l90y339r2DkZs/ldcWQXcwTjkbp/NbuJDGYoQ3awBgaT3GXOFkm3OkVpz6Z86TywYcya0eVP2r1kTV90f3krGQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
       "funding": [
         {
           "type": "github",
@@ -8016,6 +8065,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/forever-monitor/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/forever-monitor/node_modules/chokidar": {
@@ -8598,6 +8658,16 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.3",
@@ -10010,7 +10080,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11337,9 +11419,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -15235,9 +15317,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15907,9 +15989,9 @@
       }
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -16329,6 +16411,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "fast-uri": ">=4.1.1",
     "js-yaml@^3": "3.15.0",
     "shell-quote": ">=1.9.0",
-    "tar": ">=7.5.19",
     "cpx": {
       "minimatch": "3.1.3",
       "glob": {

--- a/package.json
+++ b/package.json
@@ -118,10 +118,10 @@
   "overrides": {
     "form-data": "^4.0.6",
     "@eslint/eslintrc": {
-      "minimatch": "3.1.3"
+      "minimatch": "3.1.4"
     },
     "@humanwhocodes/config-array": {
-      "minimatch": "3.1.3"
+      "minimatch": "3.1.4"
     },
     "@isaacs/brace-expansion": "5.0.1",
     "@remix-run/router": "1.23.2",
@@ -135,20 +135,20 @@
     "js-yaml@^3": "3.15.0",
     "shell-quote": ">=1.9.0",
     "cpx": {
-      "minimatch": "3.1.3",
+      "minimatch": "3.1.4",
       "glob": {
-        "minimatch": "3.1.3"
+        "minimatch": "3.1.4"
       }
     },
     "eslint": {
-      "minimatch": "3.1.3"
+      "minimatch": "3.1.4"
     },
     "eslint-plugin-import": {
-      "minimatch": "3.1.3"
+      "minimatch": "3.1.4"
     },
     "forever": {
       "forever-monitor": {
-        "minimatch": "3.1.3"
+        "minimatch": "3.1.4"
       }
     },
     "flatted": "3.4.2",
@@ -157,7 +157,7 @@
     "nconf": "0.11.4",
     "nyc": {
       "test-exclude": {
-        "minimatch": "3.1.3"
+        "minimatch": "3.1.4"
       }
     },
     "serialize-javascript": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@datadog/browser-rum": "^6.6.4",
     "@datadog/browser-rum-react": "^6.6.4",
     "autoprefixer": "^10.4.18",
-    "axios": "^1.13.5",
+    "axios": "^1.18.0",
     "clsx": "^2.1.0",
     "config": "^3.3.7",
     "cors": "^2.8.5",
@@ -98,7 +98,7 @@
     "forever": "^4.0.3",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^9.1.4",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "lint-staged": "^15.4.1",
     "nyc": "^15.1.0",
     "remark-cli": "^10.0.0",
@@ -129,8 +129,12 @@
       "minimatch": "9.0.7"
     },
     "braces": "3.0.3",
-    "fast-uri": ">=3.1.2",
-    "shell-quote": ">=1.8.4",
+    "brace-expansion@^1": "1.1.16",
+    "brace-expansion@^5": "5.0.7",
+    "fast-uri": ">=4.1.1",
+    "js-yaml@^3": "3.15.0",
+    "shell-quote": ">=1.9.0",
+    "tar": ">=7.5.19",
     "cpx": {
       "minimatch": "3.1.3",
       "glob": {


### PR DESCRIPTION
## Context

The CI `scan` job runs Trivy against the built Docker image at `severity: HIGH,CRITICAL` with `ignore-unfixed: true` and `exit-code: 1`, then fails the job if anything is found. It has been failing repo-wide on a set of HIGH/CRITICAL npm CVEs that are not tied to any single feature, so every open PR shows a red `scan`. This clears them at the source so the gate reflects real risk again.

## What this changes

Upgrades the vulnerable packages rather than suppressing the CVEs:

- **axios** `^1.13.5` → `^1.18.0` (resolves `1.18.1`) — GHSA-gcfj-64vw-6mp9 (proxy bypass after interceptor config cloning).
- **js-yaml** — direct `^4.1.0` → `^4.3.0`, and an override forcing the transitive 3.x line to `3.15.0` — CVE-2026-59869 (DoS via crafted YAML).
- **fast-uri** override `>=3.1.2` → `>=4.1.1` — CVE-2026-13676, CVE-2026-16221.
- **shell-quote** override `>=1.8.4` → `>=1.9.0` — CVE-2026-13311.
- **brace-expansion** overrides `^1` → `1.1.16`, `^5` → `5.0.7` — CVE-2026-13149.
- **tar** (CRITICAL CVE-2026-59873 + HIGH CVE-2026-59874): tar is not in `package-lock.json` at all — it ships only inside the npm CLI bundled in the Docker image, so a package override cannot reach it. Fixed by bumping the Dockerfile's pinned **npm `11.11.0` → `12.0.1`**, which bundles `tar ^7.5.19` (patched) and `minimatch ^10.2.5`. `node:22-alpine` currently ships `v22.23.1`, which satisfies npm 12's `^22.22.2` engine requirement.

Removes the now-stale `.trivyignore` suppressions the upgrades resolve (the tar, minimatch, and axios blocks). Leaves the picomatch entry (a genuine unresolved transitive conflict) and the untracked `CVE-2026-48815` entry untouched — both are out of scope here.

## How it works

`package.json` gets the direct axios/js-yaml bumps and the tightened/added overrides; `package-lock.json` is regenerated with `npm install`. `npm ls` confirms every target package resolves to a fixed version and no vulnerable copy remains. The tar/minimatch fix is the Dockerfile npm bump — it changes which `tar`/`minimatch` the built image carries, which is what Trivy scans.

Verified locally: `npm run lint:ts` clean (only pre-existing warnings), `npm run build:frontend` compiles, and the tree shows axios 1.18.1, js-yaml 3.15.0 + 4.3.0, fast-uri 4.1.1, shell-quote 1.10.0, brace-expansion 1.1.16 + 5.0.7 (and no tar).

This unblocks the `scan` gate for the whole repo, so the other open PRs go green once rebased on this.
