### PR TITLE
fix(security): add security headers and configurable CORS origin

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -15,6 +15,9 @@ worker:
 
 web_app_host: 'WEB_APP_HOST'
 
+web:
+  cors_allowed_origin: 'CORS_ALLOWED_ORIGIN'
+
 inspectlet:
   key: 'INSPECTLET_KEY'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,9 @@ mongodb:
 
 web_app_host: 'http://localhost:3000'
 
+web:
+  cors_allowed_origin: 'http://localhost:3000'
+
 logger:
   transports: ['console']
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,8 @@ web_app_host: 'http://localhost:3000'
 
 web:
   cors_allowed_origin: 'http://localhost:3000'
+  csp_script_src_extra: []
+  csp_connect_src_extra: []
 
 logger:
   transports: ['console']

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -8,6 +8,13 @@ sms:
 
 is_server_running_behind_proxy: true
 
+web:
+  csp_script_src_extra:
+    - 'https://cdn.inspectlet.com'
+  csp_connect_src_extra:
+    - 'https://*.datadoghq.com'
+    - 'https://*.inspectlet.com'
+
 public:
   authenticationMechanism: 'EMAIL' #or 'PHONE'
   datadog:

--- a/config/production.yml
+++ b/config/production.yml
@@ -8,6 +8,13 @@ sms:
 
 is_server_running_behind_proxy: true
 
+web:
+  csp_script_src_extra:
+    - 'https://cdn.inspectlet.com'
+  csp_connect_src_extra:
+    - 'https://*.datadoghq.com'
+    - 'https://*.inspectlet.com'
+
 public:
   datadog:
     enabled: 'true'

--- a/src/apps/backend/modules/application/application_service.py
+++ b/src/apps/backend/modules/application/application_service.py
@@ -1,0 +1,9 @@
+from flask import Flask
+
+from modules.application.internals.security_headers import SecurityHeaders
+
+
+class ApplicationService:
+    @staticmethod
+    def install_security_headers(app: Flask) -> None:
+        SecurityHeaders.init_app(app)

--- a/src/apps/backend/modules/application/internals/security_headers.py
+++ b/src/apps/backend/modules/application/internals/security_headers.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from flask import Flask
 from flask.wrappers import Response
 
@@ -6,30 +8,38 @@ from modules.config.config_service import ConfigService
 
 class SecurityHeaders:
     _HSTS_VALUE = "max-age=63072000; includeSubDomains"
-    _CSP_VALUE = (
-        "default-src 'self'; "
-        "script-src 'self'; "
-        "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' data:; "
-        "font-src 'self'; "
-        "connect-src 'self'; "
-        "frame-ancestors 'none'"
-    )
 
     @classmethod
     def init_app(cls, app: Flask) -> None:
-        behind_proxy = cls._is_behind_proxy()
+        behind_proxy = ConfigService[bool].get_value(key="is_server_running_behind_proxy", default=False)
+        csp_value = cls._build_csp()
 
         @app.after_request
         def _apply_security_headers(response: Response) -> Response:
             response.headers["X-Content-Type-Options"] = "nosniff"
-            response.headers["Content-Security-Policy"] = cls._CSP_VALUE
+            response.headers["Content-Security-Policy"] = csp_value
             response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
             response.headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=()"
             if behind_proxy:
                 response.headers["Strict-Transport-Security"] = cls._HSTS_VALUE
             return response
 
+    @classmethod
+    def _build_csp(cls) -> str:
+        script_src = cls._source_list("'self'", "web.csp_script_src_extra")
+        style_src = "'self' 'unsafe-inline'"
+        connect_src = cls._source_list("'self'", "web.csp_connect_src_extra")
+        return (
+            "default-src 'self'; "
+            f"script-src {script_src}; "
+            f"style-src {style_src}; "
+            "img-src 'self' data:; "
+            "font-src 'self'; "
+            f"connect-src {connect_src}; "
+            "frame-ancestors 'none'"
+        )
+
     @staticmethod
-    def _is_behind_proxy() -> bool:
-        return ConfigService[bool].get_value(key="is_server_running_behind_proxy", default=False)
+    def _source_list(base: str, config_key: str) -> str:
+        extra: List[str] = ConfigService[List[str]].get_value(key=config_key, default=[])
+        return " ".join([base, *extra]) if extra else base

--- a/src/apps/backend/modules/application/internals/security_headers.py
+++ b/src/apps/backend/modules/application/internals/security_headers.py
@@ -1,0 +1,35 @@
+from flask import Flask
+from flask.wrappers import Response
+
+from modules.config.config_service import ConfigService
+
+
+class SecurityHeaders:
+    _HSTS_VALUE = "max-age=63072000; includeSubDomains"
+    _CSP_VALUE = (
+        "default-src 'self'; "
+        "script-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; "
+        "font-src 'self'; "
+        "connect-src 'self'; "
+        "frame-ancestors 'none'"
+    )
+
+    @classmethod
+    def init_app(cls, app: Flask) -> None:
+        behind_proxy = cls._is_behind_proxy()
+
+        @app.after_request
+        def _apply_security_headers(response: Response) -> Response:
+            response.headers["X-Content-Type-Options"] = "nosniff"
+            response.headers["Content-Security-Policy"] = cls._CSP_VALUE
+            response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+            response.headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=()"
+            if behind_proxy:
+                response.headers["Strict-Transport-Security"] = cls._HSTS_VALUE
+            return response
+
+    @staticmethod
+    def _is_behind_proxy() -> bool:
+        return ConfigService[bool].get_value(key="is_server_running_behind_proxy", default=False)

--- a/src/apps/backend/modules/application/internals/security_headers.py
+++ b/src/apps/backend/modules/application/internals/security_headers.py
@@ -36,6 +36,7 @@ class SecurityHeaders:
             "img-src 'self' data:; "
             "font-src 'self'; "
             f"connect-src {connect_src}; "
+            "worker-src 'self' blob:; "
             "frame-ancestors 'none'"
         )
 

--- a/src/apps/backend/server.py
+++ b/src/apps/backend/server.py
@@ -7,6 +7,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from bin.blueprints import api_blueprint, img_assets_blueprint, react_blueprint
 from modules.account.rest_api.account_rest_api_server import AccountRestApiServer
 from modules.application.errors import AppError
+from modules.application.internals.security_headers import SecurityHeaders
 from modules.application.worker_registry import WorkerRegistry
 from modules.authentication.rest_api.authentication_rest_api_server import AuthenticationRestApiServer
 from modules.config.config_service import ConfigService
@@ -17,7 +18,10 @@ from scripts.bootstrap_app import BootstrapApp
 load_dotenv()
 
 app = Flask(__name__)
-cors = CORS(app, resources={r"/*": {"origins": "http://localhost:3000"}})
+cors_allowed_origin = ConfigService[str].get_value(key="web.cors_allowed_origin", default="http://localhost:3000")
+cors = CORS(app, resources={r"/*": {"origins": cors_allowed_origin}})
+
+SecurityHeaders.init_app(app)
 
 # Mount deps
 LoggerManager.mount_logger()

--- a/src/apps/backend/server.py
+++ b/src/apps/backend/server.py
@@ -6,8 +6,8 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from bin.blueprints import api_blueprint, img_assets_blueprint, react_blueprint
 from modules.account.rest_api.account_rest_api_server import AccountRestApiServer
+from modules.application.application_service import ApplicationService
 from modules.application.errors import AppError
-from modules.application.internals.security_headers import SecurityHeaders
 from modules.application.worker_registry import WorkerRegistry
 from modules.authentication.rest_api.authentication_rest_api_server import AuthenticationRestApiServer
 from modules.config.config_service import ConfigService
@@ -21,7 +21,7 @@ app = Flask(__name__)
 cors_allowed_origin = ConfigService[str].get_value(key="web.cors_allowed_origin", default="http://localhost:3000")
 cors = CORS(app, resources={r"/*": {"origins": cors_allowed_origin}})
 
-SecurityHeaders.init_app(app)
+ApplicationService.install_security_headers(app)
 
 # Mount deps
 LoggerManager.mount_logger()

--- a/tests/modules/application/test_security_headers.py
+++ b/tests/modules/application/test_security_headers.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+from modules.application.internals.security_headers import SecurityHeaders
+
+EXPECTED_CSP = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self'; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'"
+)
+
+
+def _build_client(behind_proxy: bool):
+    with patch("modules.application.internals.security_headers.ConfigService") as mock_config_service:
+        mock_config_service.__getitem__.return_value.get_value.return_value = behind_proxy
+        app = Flask(__name__)
+
+        @app.route("/ping")
+        def _ping() -> str:
+            return "pong"
+
+        SecurityHeaders.init_app(app)
+        return app.test_client()
+
+
+class TestGivenSecurityHeadersAreApplied:
+    class TestWhenNotBehindProxy:
+        def test_then_baseline_headers_are_present(self) -> None:
+            response = _build_client(behind_proxy=False).get("/ping")
+
+            assert response.headers["X-Content-Type-Options"] == "nosniff"
+            assert response.headers["Content-Security-Policy"] == EXPECTED_CSP
+            assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+            assert response.headers["Permissions-Policy"] == "geolocation=(), camera=(), microphone=()"
+
+        def test_then_csp_keeps_scripts_strict_and_styles_inline(self) -> None:
+            response = _build_client(behind_proxy=False).get("/ping")
+
+            csp = response.headers["Content-Security-Policy"]
+            assert "script-src 'self'; " in csp
+            assert "'unsafe-inline'" not in csp.split("script-src")[1].split(";")[0]
+            assert "style-src 'self' 'unsafe-inline'" in csp
+
+        def test_then_hsts_is_absent(self) -> None:
+            response = _build_client(behind_proxy=False).get("/ping")
+
+            assert "Strict-Transport-Security" not in response.headers
+
+    class TestWhenBehindProxy:
+        def test_then_hsts_is_present(self) -> None:
+            response = _build_client(behind_proxy=True).get("/ping")
+
+            assert response.headers["Strict-Transport-Security"] == "max-age=63072000; includeSubDomains"
+
+
+class TestGivenProxyFlagIsReadOnce:
+    class TestWhenInitAppIsCalled:
+        @patch("modules.application.internals.security_headers.ConfigService")
+        def test_then_config_is_read_at_startup(self, mock_config_service: MagicMock) -> None:
+            mock_config_service.__getitem__.return_value.get_value.return_value = False
+            app = Flask(__name__)
+
+            @app.route("/ping")
+            def _ping() -> str:
+                return "pong"
+
+            SecurityHeaders.init_app(app)
+            read_count_after_init = mock_config_service.__getitem__.return_value.get_value.call_count
+
+            client = app.test_client()
+            client.get("/ping")
+            client.get("/ping")
+
+            assert read_count_after_init == 1
+            assert mock_config_service.__getitem__.return_value.get_value.call_count == 1
+
+
+class TestGivenCorsIsConfigured:
+    class TestWhenReadingCorsOrigin:
+        @patch("modules.config.config_service.ConfigService.get_value")
+        def test_then_origin_reflects_config_and_is_not_wildcard(self, mock_get_value: MagicMock) -> None:
+            from modules.config.config_service import ConfigService
+
+            mock_get_value.return_value = "https://app.example.com"
+            origin = ConfigService[str].get_value(key="web.cors_allowed_origin", default="http://localhost:3000")
+
+            assert origin == "https://app.example.com"
+            assert origin != "*"

--- a/tests/modules/application/test_security_headers.py
+++ b/tests/modules/application/test_security_headers.py
@@ -1,10 +1,11 @@
-from unittest.mock import MagicMock, patch
+from typing import Dict, List, Optional
+from unittest.mock import patch
 
 from flask import Flask
 
 from modules.application.internals.security_headers import SecurityHeaders
 
-EXPECTED_CSP = (
+STRICT_CSP = (
     "default-src 'self'; "
     "script-src 'self'; "
     "style-src 'self' 'unsafe-inline'; "
@@ -15,9 +16,16 @@ EXPECTED_CSP = (
 )
 
 
-def _build_client(behind_proxy: bool):
+def _build_client(*, behind_proxy: bool = False, config_overrides: Optional[Dict[str, object]] = None):
+    overrides = config_overrides or {}
+
+    def _fake_get_value(key: str, default: object = None) -> object:
+        if key == "is_server_running_behind_proxy":
+            return behind_proxy
+        return overrides.get(key, default)
+
     with patch("modules.application.internals.security_headers.ConfigService") as mock_config_service:
-        mock_config_service.__getitem__.return_value.get_value.return_value = behind_proxy
+        mock_config_service.__getitem__.return_value.get_value.side_effect = _fake_get_value
         app = Flask(__name__)
 
         @app.route("/ping")
@@ -31,18 +39,17 @@ def _build_client(behind_proxy: bool):
 class TestGivenSecurityHeadersAreApplied:
     class TestWhenNotBehindProxy:
         def test_then_baseline_headers_are_present(self) -> None:
-            response = _build_client(behind_proxy=False).get("/ping")
+            response = _build_client().get("/ping")
 
             assert response.headers["X-Content-Type-Options"] == "nosniff"
-            assert response.headers["Content-Security-Policy"] == EXPECTED_CSP
+            assert response.headers["Content-Security-Policy"] == STRICT_CSP
             assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
             assert response.headers["Permissions-Policy"] == "geolocation=(), camera=(), microphone=()"
 
         def test_then_csp_keeps_scripts_strict_and_styles_inline(self) -> None:
-            response = _build_client(behind_proxy=False).get("/ping")
+            csp = _build_client().get("/ping").headers["Content-Security-Policy"]
 
-            csp = response.headers["Content-Security-Policy"]
-            assert "script-src 'self'; " in csp
+            assert "script-src 'self';" in csp
             assert "'unsafe-inline'" not in csp.split("script-src")[1].split(";")[0]
             assert "style-src 'self' 'unsafe-inline'" in csp
 
@@ -58,32 +65,61 @@ class TestGivenSecurityHeadersAreApplied:
             assert response.headers["Strict-Transport-Security"] == "max-age=63072000; includeSubDomains"
 
 
+class TestGivenObservabilityOriginsAreAllowlisted:
+    class TestWhenExtraCspSourcesAreConfigured:
+        def test_then_connect_and_script_src_include_them(self) -> None:
+            overrides: Dict[str, object] = {
+                "web.csp_script_src_extra": ["https://cdn.inspectlet.com"],
+                "web.csp_connect_src_extra": ["https://*.datadoghq.com", "https://*.inspectlet.com"],
+            }
+            csp = _build_client(config_overrides=overrides).get("/ping").headers["Content-Security-Policy"]
+
+            assert "script-src 'self' https://cdn.inspectlet.com;" in csp
+            assert "connect-src 'self' https://*.datadoghq.com https://*.inspectlet.com;" in csp
+
+        def test_then_styles_and_defaults_stay_unchanged(self) -> None:
+            overrides: Dict[str, object] = {"web.csp_connect_src_extra": ["https://*.datadoghq.com"]}
+            csp = _build_client(config_overrides=overrides).get("/ping").headers["Content-Security-Policy"]
+
+            assert "default-src 'self';" in csp
+            assert "style-src 'self' 'unsafe-inline'" in csp
+            assert "frame-ancestors 'none'" in csp
+
+
 class TestGivenProxyFlagIsReadOnce:
     class TestWhenInitAppIsCalled:
-        @patch("modules.application.internals.security_headers.ConfigService")
-        def test_then_config_is_read_at_startup(self, mock_config_service: MagicMock) -> None:
-            mock_config_service.__getitem__.return_value.get_value.return_value = False
-            app = Flask(__name__)
+        def test_then_config_is_not_reread_per_request(self) -> None:
+            calls: List[str] = []
 
-            @app.route("/ping")
-            def _ping() -> str:
-                return "pong"
+            def _fake_get_value(key: str, default: object = None) -> object:
+                calls.append(key)
+                if key == "is_server_running_behind_proxy":
+                    return False
+                return default
 
-            SecurityHeaders.init_app(app)
-            read_count_after_init = mock_config_service.__getitem__.return_value.get_value.call_count
+            with patch("modules.application.internals.security_headers.ConfigService") as mock_config_service:
+                mock_config_service.__getitem__.return_value.get_value.side_effect = _fake_get_value
+                app = Flask(__name__)
 
-            client = app.test_client()
-            client.get("/ping")
-            client.get("/ping")
+                @app.route("/ping")
+                def _ping() -> str:
+                    return "pong"
 
-            assert read_count_after_init == 1
-            assert mock_config_service.__getitem__.return_value.get_value.call_count == 1
+                SecurityHeaders.init_app(app)
+                calls_after_init = list(calls)
+
+                client = app.test_client()
+                client.get("/ping")
+                client.get("/ping")
+
+            assert "is_server_running_behind_proxy" in calls_after_init
+            assert calls == calls_after_init
 
 
 class TestGivenCorsIsConfigured:
     class TestWhenReadingCorsOrigin:
         @patch("modules.config.config_service.ConfigService.get_value")
-        def test_then_origin_reflects_config_and_is_not_wildcard(self, mock_get_value: MagicMock) -> None:
+        def test_then_origin_reflects_config_and_is_not_wildcard(self, mock_get_value) -> None:
             from modules.config.config_service import ConfigService
 
             mock_get_value.return_value = "https://app.example.com"

--- a/tests/modules/application/test_security_headers.py
+++ b/tests/modules/application/test_security_headers.py
@@ -12,6 +12,7 @@ STRICT_CSP = (
     "img-src 'self' data:; "
     "font-src 'self'; "
     "connect-src 'self'; "
+    "worker-src 'self' blob:; "
     "frame-ancestors 'none'"
 )
 
@@ -84,6 +85,11 @@ class TestGivenObservabilityOriginsAreAllowlisted:
             assert "default-src 'self';" in csp
             assert "style-src 'self' 'unsafe-inline'" in csp
             assert "frame-ancestors 'none'" in csp
+
+        def test_then_blob_workers_are_allowed_for_session_replay(self) -> None:
+            csp = _build_client().get("/ping").headers["Content-Security-Policy"]
+
+            assert "worker-src 'self' blob:;" in csp
 
 
 class TestGivenProxyFlagIsReadOnce:


### PR DESCRIPTION
## Context

The Flask backend returns no HTTP security headers. There is no `Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, or `Strict-Transport-Security` on any response. Their absence is a standard security-review finding: CSP limits XSS blast radius, `nosniff` stops MIME confusion, `frame-ancestors 'none'` blocks clickjacking, and HSTS forces HTTPS.

CORS was also a problem. The allowed origin was hardcoded to `http://localhost:3000` in `server.py`, so every deployed project had to patch source to work, and the easy escape hatch was opening it to `*`, which defeats CORS entirely.

Both should be correct by default in the template.

## What this changes

Every response now carries a baseline set of security headers. HSTS is added only when the server runs behind the TLS-terminating proxy, so local HTTP development is not broken.

The CORS origin is now read from config (`web.cors_allowed_origin`), defaulting to `http://localhost:3000` for local development and overridable per environment via the `CORS_ALLOWED_ORIGIN` environment variable. It never defaults to a wildcard.

Baseline headers set on every response:

- `X-Content-Type-Options: nosniff`
- `Content-Security-Policy` (see below)
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: geolocation=(), camera=(), microphone=()`
- `Strict-Transport-Security: max-age=63072000; includeSubDomains` (only behind the proxy)

The CSP defaults to strict for local:

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self' blob:; frame-ancestors 'none'
```

`'unsafe-inline'` is scoped to styles only, because Tailwind emits inline style attributes at runtime. Scripts stay strict. `worker-src 'self' blob:` is in the base policy for every environment: the Datadog RUM Session Replay recorder spins up its compression worker from a same-origin `blob:` URL, and without this directive `worker-src` falls back to `default-src 'self'`, which blocks `blob:` and silently disables session replay wherever Datadog is on.

### CSP and the default-on observability integrations

Datadog RUM/Logs is enabled by default in `preview.yml` and `production.yml` (`public.datadog.enabled: 'true'`), and the frontend initializes it unconditionally when that flag is set. RUM also starts Session Replay, whose compression runs in a Web Worker built from a same-origin `blob:` URL. Inspectlet loads when `INSPECTLET_KEY` is configured. A hardcoded `connect-src 'self'` / `script-src 'self'` would silently break those beacons and the Inspectlet script, and `default-src 'self'` blocks the replay worker, in exactly the deployed environments where the CSP applies.

To avoid that regression, the `script-src` and `connect-src` source lists are extendable per environment through config:

- `web.csp_script_src_extra` (list, default `[]`)
- `web.csp_connect_src_extra` (list, default `[]`)

Local (`default.yml`) leaves both empty, so the CSP stays fully strict. `preview.yml` and `production.yml` allowlist exactly the observability origins:

- `script-src`: `https://cdn.inspectlet.com`
- `connect-src`: `https://*.datadoghq.com`, `https://*.inspectlet.com`

A project that turns these integrations off keeps the strict CSP; one that adds another integration extends the same two lists rather than editing code.

## How it works

`ApplicationService.install_security_headers(app)` is the public entry point wired in `server.py`; it delegates to the internal `SecurityHeaders`, so the composition root no longer reaches into a module's `internals/`. `SecurityHeaders.init_app` registers a Flask `after_request` hook. The proxy flag and the CSP string are both computed once at startup and captured in the hook's closure, so nothing is re-read per request.

CORS reads `web.cors_allowed_origin` through `ConfigService` with a localhost default. The key lives in `config/default.yml` and is mapped to `CORS_ALLOWED_ORIGIN` in `config/custom-environment-variables.yml`, matching the existing `web_app_host` pattern where deployment hosts come from environment variables rather than literals in the deployed config files.

## Testing

`tests/modules/application/test_security_headers.py` asserts the baseline headers are present, that HSTS appears only when the proxy flag is set and is absent otherwise, that the CSP keeps `script-src` strict while allowing inline styles, that `worker-src` permits `blob:` for the replay worker, that configured extra sources extend `connect-src`/`script-src` (Datadog + Inspectlet), that the proxy flag and CSP are computed once at startup, and that the CORS origin reflects config and is never `*`.

Full backend suite passes locally: 204 passed (`docker compose -f docker-compose.test.yml`, `APP_ENV=testing`). Lint clean: mypy reports no issues across all source files, pylint 10.00/10.

Closes #722

