### PR TITLE
test(backend): purge Celery broker queues between tests for isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ run-flower:
 
 
 run-test:
-	PYTHONPATH=src/apps/backend pipenv run pytest --disable-warnings -s -x -v --cov=src/apps/backend --cov-report=xml:/app/output/coverage.xml tests
+	APP_ENV=testing PYTHONPATH=src/apps/backend pipenv run pytest --disable-warnings -s -x -v --cov=src/apps/backend --cov-report=xml:/app/output/coverage.xml tests
 
 run-engine-winx86:
 	echo "This command is specifically for Windows platform \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+import os
 from typing import Iterator
 
 import pytest
 from celery_app import app as celery_app
 
 from modules.logger.logger_manager import LoggerManager
+
+TESTING_APP_ENV = "testing"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -14,11 +17,17 @@ def mount_loggers() -> None:
     LoggerManager.mount_logger()
 
 
+def _running_against_testing_broker() -> bool:
+    return os.environ.get("APP_ENV", "development") == TESTING_APP_ENV
+
+
 def _broker_queue_names() -> list[str]:
     return [getattr(queue, "name", queue) for queue in (celery_app.conf.task_queues or [])]
 
 
 def _purge_broker_queues() -> None:
+    if not _running_against_testing_broker():
+        return
     with celery_app.connection_for_write() as connection:
         for name in _broker_queue_names():
             connection.default_channel.queue_purge(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+from typing import Iterator
+
 import pytest
+from celery_app import app as celery_app
 
 from modules.logger.logger_manager import LoggerManager
 
@@ -9,3 +12,25 @@ def mount_loggers() -> None:
     # as it runs once at server boot. Doing it here, session-scoped, is the correct home for it. Running
     # it in per-test setup stacked a duplicate handler for every test and multiplied log output.
     LoggerManager.mount_logger()
+
+
+def _broker_queue_names() -> list[str]:
+    return [getattr(queue, "name", queue) for queue in (celery_app.conf.task_queues or [])]
+
+
+def _purge_broker_queues() -> None:
+    with celery_app.connection_for_write() as connection:
+        for name in _broker_queue_names():
+            connection.default_channel.queue_purge(name)
+
+
+def broker_queue_depth(name: str) -> int:
+    with celery_app.connection_for_write() as connection:
+        return connection.default_channel._size(name)
+
+
+@pytest.fixture(autouse=True)
+def purge_broker_queues() -> Iterator[None]:
+    _purge_broker_queues()
+    yield
+    _purge_broker_queues()

--- a/tests/modules/application/test_broker_isolation.py
+++ b/tests/modules/application/test_broker_isolation.py
@@ -1,0 +1,16 @@
+from modules.application.workers.health_check_worker import HealthCheckWorker
+from tests.conftest import broker_queue_depth
+
+DEFAULT_QUEUE = "default"
+
+
+class TestGivenTheBrokerIsPurgedBetweenTests:
+    class TestWhenATaskIsEnqueued:
+        def test_then_the_queue_holds_exactly_one_message(self) -> None:
+            HealthCheckWorker.perform_async()
+
+            assert broker_queue_depth(DEFAULT_QUEUE) == 1
+
+    class TestWhenTheNextTestRuns:
+        def test_then_the_queue_starts_empty(self) -> None:
+            assert broker_queue_depth(DEFAULT_QUEUE) == 0


### PR DESCRIPTION
Closes #717

## Context

The backend runs background work on Celery over a Redis broker. Any code path that calls `perform_async` pushes a message onto one of the app's declared queues (`critical`, `default`, `low`). During tests there is no worker draining those queues, so an enqueued message just sits on the broker.

The test suite had no fixture resetting broker state between tests. That is a problem in two ways. A test that wants to assert "this action enqueued exactly one job" starts from whatever backlog earlier tests left behind, so it can pass for the wrong reason or be impossible to write. And a stale message can later fire against state a subsequent test deleted if a worker ever drains the queue, producing order-dependent failures. This grows worse as the template adds features that enqueue work.

This is the test-isolation counterpart to the known worker bugs (#650). It is independent of that fix: even once workers execute, tests still need a clean broker between cases.

## What this changes

Adds an autouse, function-scoped pytest fixture that purges every queue in the Celery app's `task_queues` before and after each test. The suite now ends at the queue depth it started at, and any test asserting on queue contents begins from empty. No change to how tasks run in production.

## How it works

The fixture lives in `tests/conftest.py`, so it applies to the whole suite without any test opting in.

- Queue names come from `celery_app.app.conf.task_queues`. In this app that config is a dict keyed by queue name; the helper reads `getattr(queue, "name", queue)` so it also works if an entry is a kombu `Queue` object.
- Purging uses the broker connection: `connection.default_channel.queue_purge(name)` for each declared queue, run once before `yield` and once after.
- A small `broker_queue_depth(name)` helper reads a queue's current depth without draining it, so a test can assert on it. It uses the Redis transport channel's size read rather than a passive AMQP `queue_declare`, because on Redis an empty queue has no backing key and a passive declare raises `NOT_FOUND` instead of returning zero.

One test exercises the guarantee: it enqueues a task via `HealthCheckWorker.perform_async()` and asserts the `default` queue holds exactly one message. A second test asserts the queue starts empty, which holds only because the autouse fixture purged between the two.

Verified locally against the testing Redis broker: the application module tests (20) pass, including the two new ones.
