### PR TITLE
feat(backend): stamp updated_at on every generic repository write

### DIFF
--- a/src/apps/backend/modules/account/internal/account_writer.py
+++ b/src/apps/backend/modules/account/internal/account_writer.py
@@ -52,9 +52,7 @@ class AccountWriter:
     @staticmethod
     def update_password_by_account_id(account_id: str, password: str) -> Account:
         hashed_password = AccountUtil.hash_password(password=password)
-        updated_account = AccountRepository.update(
-            account_id, {"hashed_password": hashed_password, "updated_at": datetime.now(UTC)}
-        )
+        updated_account = AccountRepository.update(account_id, {"hashed_password": hashed_password})
         if updated_account is None:
             raise AccountWithIdNotFoundError(id=account_id)
 
@@ -69,9 +67,6 @@ class AccountWriter:
 
         if params.last_name is not None:
             update_fields["last_name"] = params.last_name
-
-        if update_fields:
-            update_fields["updated_at"] = datetime.now(UTC)
 
         updated_account = AccountRepository.update(account_id, update_fields)
         if updated_account is None:

--- a/src/apps/backend/modules/application/repository.py
+++ b/src/apps/backend/modules/application/repository.py
@@ -2,6 +2,7 @@ import dataclasses
 import os
 import urllib.parse
 from abc import ABC, abstractmethod
+from datetime import UTC, datetime
 from typing import Any, ClassVar, Optional
 
 from bson import ObjectId
@@ -218,7 +219,8 @@ class ApplicationRepository[EntityT, QueryT: QueryParams](ABC):
         object_id = cls._to_object_id(entity_id)
         if object_id is None:
             return False
-        result = cls.collection().update_one({"_id": object_id}, {"$set": fields})
+        patch = {"updated_at": datetime.now(UTC), **fields}
+        result = cls.collection().update_one({"_id": object_id}, {"$set": patch})
         return bool(result.matched_count > 0)
 
     @classmethod

--- a/src/apps/backend/modules/application/repository.py
+++ b/src/apps/backend/modules/application/repository.py
@@ -219,6 +219,8 @@ class ApplicationRepository[EntityT, QueryT: QueryParams](ABC):
         object_id = cls._to_object_id(entity_id)
         if object_id is None:
             return False
+        if not fields:
+            return cls._count({"_id": object_id}) > 0
         patch = {"updated_at": datetime.now(UTC), **fields}
         result = cls.collection().update_one({"_id": object_id}, {"$set": patch})
         return bool(result.matched_count > 0)

--- a/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
+++ b/src/apps/backend/modules/authentication/internals/otp/otp_writer.py
@@ -1,5 +1,4 @@
 from dataclasses import asdict
-from datetime import UTC, datetime
 
 from modules.account.types import PhoneNumber
 from modules.authentication.errors import OTPExpiredError, OTPIncorrectError
@@ -13,9 +12,7 @@ class OTPWriter:
     def expire_previous_otps(phone_number: PhoneNumber) -> None:
         previous_otps = OTPRepository.query(OTPQuery(phone_number=phone_number, active=True))
         for otp in previous_otps:
-            OTPRepository.update_fields(
-                otp.id, {"active": False, "status": str(OTPStatus.EXPIRED), "updated_at": datetime.now(UTC)}
-            )
+            OTPRepository.update_fields(otp.id, {"active": False, "status": str(OTPStatus.EXPIRED)})
 
     @staticmethod
     def create_new_otp(*, params: CreateOTPParams) -> OTP:
@@ -38,9 +35,7 @@ class OTPWriter:
         if not otp.active:
             raise OTPExpiredError()
 
-        updated_otp = OTPRepository.update(
-            otp.id, {"active": False, "status": str(OTPStatus.SUCCESS), "updated_at": datetime.now(UTC)}
-        )
+        updated_otp = OTPRepository.update(otp.id, {"active": False, "status": str(OTPStatus.SUCCESS)})
         # update() returns None only if the row vanished between the read and the patch; the read above
         # found it, so it is present here.
         assert updated_otp is not None

--- a/src/apps/backend/modules/authentication/internals/password_reset_token/password_reset_token_writer.py
+++ b/src/apps/backend/modules/authentication/internals/password_reset_token/password_reset_token_writer.py
@@ -1,5 +1,3 @@
-from datetime import UTC, datetime
-
 from modules.authentication.errors import PasswordResetTokenNotFoundError
 from modules.authentication.internals.password_reset_token.password_reset_token_util import PasswordResetTokenUtil
 from modules.authentication.internals.password_reset_token.store.password_reset_token_repository import (
@@ -20,9 +18,7 @@ class PasswordResetTokenWriter:
 
     @staticmethod
     def set_password_reset_token_as_used(password_reset_token_id: str) -> PasswordResetToken:
-        updated_token = PasswordResetTokenRepository.update(
-            password_reset_token_id, {"is_used": True, "updated_at": datetime.now(UTC)}
-        )
+        updated_token = PasswordResetTokenRepository.update(password_reset_token_id, {"is_used": True})
         if updated_token is None:
             raise PasswordResetTokenNotFoundError()
 

--- a/src/apps/backend/modules/task/internal/task_writer.py
+++ b/src/apps/backend/modules/task/internal/task_writer.py
@@ -23,9 +23,7 @@ class TaskWriter:
         # Confirm the task exists for this account (raises if not), keeping the update account-scoped.
         TaskReader.get_task(params=GetTaskParams(account_id=params.account_id, task_id=params.task_id))
 
-        TaskRepository.update_fields(
-            params.task_id, {"description": params.description, "title": params.title, "updated_at": datetime.now(UTC)}
-        )
+        TaskRepository.update_fields(params.task_id, {"description": params.description, "title": params.title})
 
         return TaskReader.get_task(params=GetTaskParams(account_id=params.account_id, task_id=params.task_id))
 

--- a/tests/modules/application/test_base_model.py
+++ b/tests/modules/application/test_base_model.py
@@ -1,0 +1,55 @@
+import unittest
+from dataclasses import dataclass
+from datetime import UTC, datetime, timezone
+from typing import Optional
+
+from bson import ObjectId
+
+from modules.application.base_model import BaseModel
+
+
+@dataclass
+class SampleModel(BaseModel):
+    id: Optional[ObjectId | str] = None
+
+
+class TestBaseModel(unittest.TestCase):
+    def test_created_at_defaults_to_now_utc_aware(self) -> None:
+        model = SampleModel()
+
+        assert model.created_at is not None
+        assert model.created_at.tzinfo is not None
+        assert model.created_at.utcoffset() == UTC.utcoffset(model.created_at)
+
+    def test_naive_created_at_comes_back_utc_aware(self) -> None:
+        naive = datetime(2024, 1, 1, 12, 0, 0)
+
+        model = SampleModel(created_at=naive)
+
+        assert model.created_at is not None
+        assert model.created_at.tzinfo is UTC
+        assert model.created_at == naive.replace(tzinfo=UTC)
+
+    def test_naive_updated_at_comes_back_utc_aware(self) -> None:
+        naive = datetime(2024, 1, 1, 12, 0, 0)
+
+        model = SampleModel(created_at=datetime.now(UTC), updated_at=naive)
+
+        assert model.updated_at is not None
+        assert model.updated_at.tzinfo is UTC
+        assert model.updated_at == naive.replace(tzinfo=UTC)
+
+    def test_updated_at_falls_back_to_created_at_when_omitted(self) -> None:
+        created = datetime(2024, 3, 1, 8, 30, tzinfo=UTC)
+
+        model = SampleModel(created_at=created)
+
+        assert model.updated_at == created
+
+    def test_aware_timestamps_are_preserved(self) -> None:
+        aware = datetime(2024, 5, 1, 6, 0, tzinfo=timezone.utc)
+
+        model = SampleModel(created_at=aware, updated_at=aware)
+
+        assert model.created_at == aware
+        assert model.updated_at == aware

--- a/tests/modules/application/test_repository_timestamps.py
+++ b/tests/modules/application/test_repository_timestamps.py
@@ -1,0 +1,52 @@
+import unittest
+from datetime import UTC, datetime
+
+from modules.account.account_service import AccountService
+from modules.account.internal.store.account_repository import AccountRepository
+from modules.account.types import CreateAccountByUsernameAndPasswordParams
+from modules.task.internal.store.task_repository import TaskRepository
+from modules.task.task_service import TaskService
+from modules.task.types import CreateTaskParams
+
+
+class TestRepositoryTimestamps(unittest.TestCase):
+    def setUp(self) -> None:
+        self.account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                username="timestamps@example.com",
+                password="testpassword",
+                first_name="Time",
+                last_name="Stamps",
+            )
+        )
+
+    def tearDown(self) -> None:
+        TaskRepository.collection().delete_many({})
+        AccountRepository.collection().delete_many({})
+
+    def test_update_stamps_updated_at_without_caller_supplying_it(self) -> None:
+        task = TaskService.create_task(
+            params=CreateTaskParams(account_id=self.account.id, title="Title", description="Body")
+        )
+
+        before = datetime.now(UTC)
+        updated = TaskRepository.update(task.id, {"title": "New title"})
+        after = datetime.now(UTC)
+
+        assert updated is not None
+        assert updated.title == "New title"
+        assert updated.updated_at is not None
+        assert updated.updated_at.tzinfo is not None
+        before_ms = before.replace(microsecond=(before.microsecond // 1000) * 1000)
+        assert before_ms <= updated.updated_at <= after
+
+    def test_caller_supplied_updated_at_wins(self) -> None:
+        task = TaskService.create_task(
+            params=CreateTaskParams(account_id=self.account.id, title="Title", description="Body")
+        )
+        pinned = datetime(2020, 1, 1, tzinfo=UTC)
+
+        updated = TaskRepository.update(task.id, {"active": False, "updated_at": pinned})
+
+        assert updated is not None
+        assert updated.updated_at == pinned

--- a/tests/modules/application/test_repository_timestamps.py
+++ b/tests/modules/application/test_repository_timestamps.py
@@ -50,3 +50,20 @@ class TestRepositoryTimestamps(unittest.TestCase):
 
         assert updated is not None
         assert updated.updated_at == pinned
+
+    def test_empty_update_leaves_updated_at_untouched(self) -> None:
+        task = TaskService.create_task(
+            params=CreateTaskParams(account_id=self.account.id, title="Title", description="Body")
+        )
+        stored = TaskRepository.find(task.id)
+        assert stored is not None
+
+        unchanged = TaskRepository.update(task.id, {})
+
+        assert unchanged is not None
+        assert unchanged.updated_at == stored.updated_at
+
+    def test_empty_update_on_missing_entity_returns_none(self) -> None:
+        missing = TaskRepository.update("507f1f77bcf86cd799439011", {})
+
+        assert missing is None


### PR DESCRIPTION
## Context

Almost every stored record wants `created_at` and `updated_at`: they answer "when was this made" and "when did it last change", and they underpin audit trails, sorting, and debugging. The shared `BaseModel` already provides both as timezone-aware fields and normalizes any naive datetime to UTC on construction (a freshly created record reads `updated_at == created_at`).

The gap was on the write side. Keeping `updated_at` correct was left to each writer: every place that patched a record had to remember to also set `updated_at = datetime.now(UTC)`. That duplication is easy to forget, and a missed stamp silently leaves `updated_at` stale.

## What this changes

The generic repository now stamps `updated_at` on every write, so no writer has to remember to. A writer that needs the exact value it stored (for example a soft-delete that returns `deleted_at`) can still pass its own `updated_at` and that value wins.

Concretely:
- `ApplicationRepository.update_fields` sets `updated_at = datetime.now(UTC)` on every `$set`, unless the caller supplies its own `updated_at`. `update()` flows through the same path, so both inherit the behaviour.
- The manual `updated_at` stamps in the account, task, OTP, and password-reset-token writers are removed, since the repository now does it. Soft-delete paths keep their explicit timestamp because they return it to the caller.

## How it works

`update_fields` builds the `$set` patch as `{"updated_at": now, **fields}`. Because caller fields are spread last, a caller-supplied `updated_at` overrides the default. MongoDB stores datetimes at millisecond precision, so a read-back is the stored value truncated to milliseconds; the tests account for that.

## Tests

- `test_base_model.py`: a naive `created_at`/`updated_at` comes back UTC-aware, `updated_at` falls back to `created_at` when omitted, and already-aware values are preserved.
- `test_repository_timestamps.py`: a generic `update` with no `updated_at` stamps a fresh UTC-aware value in the expected window, and a caller-supplied `updated_at` is preserved.

Full backend suite green (222 passed) via the docker test stack; mypy clean and pylint 10.00/10.

Closes #716
