### PR TITLE
ci: run the frontend test suite in its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
 
   sonarqube:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
-    needs: [test, test-frontend]
+    needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -779,7 +779,7 @@ jobs:
           echo "❌ Trivy found vulnerabilities — failing the job."
           exit 1
 
-  test:
+  test-backend:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
 
   sonarqube:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
-    needs: test
+    needs: [test, test-frontend]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -850,3 +850,37 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+
+  test-frontend:
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '22.13.1'
+
+      - name: Cache npm downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.npm-test-frontend
+          key: npm-test-frontend-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-test-frontend-${{ runner.os }}-
+
+      - name: Install Node dependencies
+        run: npm ci --cache ~/.npm-test-frontend
+
+      - name: Run frontend tests
+        run: npm run test:frontend -- --coverage
+
+      - name: Upload frontend coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-coverage-report
+          path: output/frontend-coverage/lcov.info
+          retention-days: 1
+        continue-on-error: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,13 +145,15 @@ graph TB
     CI --> Lint[ci/lint<br/>~30s]
     CI --> Sonar[ci/sonarqube<br/>~60s]
     CI --> Review[ci/review<br/>~90s]
-    CI --> Test[ci/test<br/>~1 min]
+    CI --> TestBackend[ci/test-backend<br/>~1 min]
+    CI --> TestFrontend[ci/test-frontend<br/>~1 min]
 
     Label --> End([Complete])
     Lint --> End
     Sonar --> End
     Review --> End
-    Test --> End
+    TestBackend --> End
+    TestFrontend --> End
 
     style CI fill:#e1f5ff
     style Label fill:#f0e6ff
@@ -170,7 +172,8 @@ All jobs run in parallel and independently:
 1. **ci/lint** (~30s) - ESLint and Markdown checks for code style and potential errors
 2. **ci/sonarqube** (~60s) - Code quality metrics, complexity, and code smells
 3. **ci/review** (~90s) - Automated code review (placeholder for future AI-powered review)
-4. **ci/test** (~1 min) - Integration tests using docker-compose
+4. **ci/test-backend** (~1 min) - Backend integration tests using docker-compose
+5. **ci/test-frontend** (~1 min) - Frontend Vitest suite on Node, no backing services
 
 **Note:** All CI checks are advisory and run independently. Code merged to `main` should have passing CI checks from the PR.
 


### PR DESCRIPTION
## Context

CI has one `test` job. It builds the Docker images, boots MongoDB, and runs the backend pytest suite. That job is the only place tests run today.

A frontend Vitest suite now exists on main (`src/apps/frontend/vitest.config.ts`, `npm run test:frontend`). It is jsdom-only: it needs nothing but Node, no database and no image build. Left as-is, those tests would either not run in CI or would have to ride behind the heavy backend job, so every frontend-only change would pay for a database and a Docker build it never touches, and a frontend failure would surface inside a job whose name says "backend".

## What this changes

Adds a dedicated `test-frontend` job to the CI workflow that runs the frontend suite on its own. It runs in parallel with the backend suite on plain `ubuntu-latest` with only Node, so the two suites fail independently and frontend feedback is fast and clearly labelled. The merge gate now waits on both suites.

The existing backend `test` job is renamed to `test-backend` in the same pass, so the two checks read cleanly as `ci/test-backend` and `ci/test-frontend` side by side instead of one being the unqualified `ci/test`. Every reference to the old job name is updated: the sonar gate's `needs`, and the CI section of `docs/deployment.md`.

This PR only stands up the frontend job, renames the backend job, and wires the gate dependency. Coverage enforcement and the frontend coverage PR comment are handled separately in #713.

## How it works

The frontend job checks out, sets up Node pinned to `22.13.1` (the version already used across the repo: `.nvmrc`, `engines`, the `lint` job, and `version-bump.yml`), installs with `npm ci`, and runs `npm run test:frontend -- --coverage`.

It deliberately does not use `setup-node`'s built-in npm cache. The `lint` job already restores that shared cache, and if the two jobs start together they write into the same `_cacache/tmp`, which is not safe for concurrent writers: the loser dies with `EEXIST`. To avoid that race, this job keeps its own private cache directory (`~/.npm-test-frontend`) via `actions/cache` under a key scoped to this job, and points npm at it with `npm ci --cache ~/.npm-test-frontend`.

The Vitest config writes coverage to `output/frontend-coverage/` with an lcov reporter, so the job uploads `output/frontend-coverage/lcov.info` as an artifact (`retention-days: 1`, `continue-on-error: true`) for the Sonar job to pick up later.

Finally, the `sonarqube` gate, which previously declared `needs: test`, now declares `needs: [test-backend, test-frontend]`, so a merge is blocked until both suites pass.

Closes #712
