### PR TITLE
refactor(backend): turn on mypy strict and type-check the test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 run-lint:
 	cd src/apps/backend && \
-	pipenv run mypy --config-file mypy.ini . && \
+	MYPYPATH=. pipenv run mypy --config-file mypy.ini . ../../../tests && \
 	pipenv run pylint \
 	  --disable=all \
 	  --reports=no \

--- a/src/apps/backend/bin/blueprints.py
+++ b/src/apps/backend/bin/blueprints.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Union
+from typing import Any
 
 from flask import Blueprint, send_from_directory
 from werkzeug.wrappers import Response
@@ -27,7 +27,7 @@ def serve_config() -> Response:
 
 @react_blueprint.route("/", defaults={"path": ""})
 @react_blueprint.route("/<path:path>")
-def serve_react_home(path: Union[os.PathLike[str], str]) -> Response:
+def serve_react_home(path: os.PathLike[str] | str) -> Response:
     assert react_blueprint.static_folder, MISSING_STATIC_ROOT_ERR_MESSAGE
     return send_from_directory(react_blueprint.static_folder, "index.html")
 
@@ -50,7 +50,7 @@ img_assets_blueprint = Blueprint("image_assets", __name__, static_folder=react_i
 
 
 @img_assets_blueprint.route("/assets/img/<path:filename>")
-def serve_static_images(filename: Union[os.PathLike[str], str]) -> Response:
+def serve_static_images(filename: os.PathLike[str] | str) -> Response:
     assert img_assets_blueprint.static_folder, MISSING_STATIC_ROOT_ERR_MESSAGE
     return send_from_directory(img_assets_blueprint.static_folder, filename)
 

--- a/src/apps/backend/bin/blueprints.py
+++ b/src/apps/backend/bin/blueprints.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Union
+from typing import Any, Union
 
 from flask import Blueprint, send_from_directory
 from werkzeug.wrappers import Response
@@ -18,14 +18,16 @@ MISSING_STATIC_ROOT_ERR_MESSAGE = "Unable to resolve react root path"
 def serve_config() -> Response:
     from modules.config.config_service import ConfigService
 
-    public_config: dict = ConfigService.get_value("public") if ConfigService.has_value("public") else {}
+    public_config: dict[str, Any] = (
+        ConfigService[dict[str, Any]].get_value("public") if ConfigService.has_value("public") else {}
+    )
     config_js = f"window.Config = {json.dumps(public_config)};"
     return Response(config_js, mimetype="application/javascript")
 
 
 @react_blueprint.route("/", defaults={"path": ""})
 @react_blueprint.route("/<path:path>")
-def serve_react_home(path: Union[os.PathLike, str]) -> Response:
+def serve_react_home(path: Union[os.PathLike[str], str]) -> Response:
     assert react_blueprint.static_folder, MISSING_STATIC_ROOT_ERR_MESSAGE
     return send_from_directory(react_blueprint.static_folder, "index.html")
 
@@ -48,7 +50,7 @@ img_assets_blueprint = Blueprint("image_assets", __name__, static_folder=react_i
 
 
 @img_assets_blueprint.route("/assets/img/<path:filename>")
-def serve_static_images(filename: Union[os.PathLike, str]) -> Response:
+def serve_static_images(filename: Union[os.PathLike[str], str]) -> Response:
     assert img_assets_blueprint.static_folder, MISSING_STATIC_ROOT_ERR_MESSAGE
     return send_from_directory(img_assets_blueprint.static_folder, filename)
 

--- a/src/apps/backend/modules/account/internal/store/account_model.py
+++ b/src/apps/backend/modules/account/internal/store/account_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -20,7 +20,7 @@ class AccountModel(BaseModel):
     active: bool = True
 
     @classmethod
-    def from_bson(cls, bson_data: dict) -> "AccountModel":
+    def from_bson(cls, bson_data: dict[str, Any]) -> "AccountModel":
         phone_number_data = bson_data.get("phone_number")
         phone_number = PhoneNumber(**phone_number_data) if phone_number_data else None
         return cls(

--- a/src/apps/backend/modules/authentication/internals/otp/store/otp_model.py
+++ b/src/apps/backend/modules/authentication/internals/otp/store/otp_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -16,7 +16,7 @@ class OTPModel(BaseModel):
     status: str
 
     @classmethod
-    def from_bson(cls, bson_data: dict) -> "OTPModel":
+    def from_bson(cls, bson_data: dict[str, Any]) -> "OTPModel":
         phone_number_data = bson_data.get("phone_number")
         if not phone_number_data:
             raise ValueError("Phone number data is required for OTPModel")

--- a/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_model.py
+++ b/src/apps/backend/modules/authentication/internals/password_reset_token/store/password_reset_token_model.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -18,7 +18,7 @@ class PasswordResetTokenModel(BaseModel):
     is_used: bool = False
 
     @classmethod
-    def from_bson(cls, bson_data: dict) -> "PasswordResetTokenModel":
+    def from_bson(cls, bson_data: dict[str, Any]) -> "PasswordResetTokenModel":
         return cls(
             account=bson_data.get("account"),
             created_at=bson_data.get("created_at"),

--- a/src/apps/backend/modules/authentication/rest_api/access_auth_middleware.py
+++ b/src/apps/backend/modules/authentication/rest_api/access_auth_middleware.py
@@ -32,7 +32,7 @@ def enforce_account_ownership(account_id: str) -> None:
         raise UnauthorizedAccessError("Unauthorized access.")
 
 
-def access_auth_middleware(next_function: Callable) -> Callable:
+def access_auth_middleware(next_function: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(next_function)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if "account_id" in kwargs:

--- a/src/apps/backend/modules/authentication/rest_api/access_token_view.py
+++ b/src/apps/backend/modules/authentication/rest_api/access_token_view.py
@@ -5,13 +5,12 @@ from flask.typing import ResponseReturnValue
 from flask.views import MethodView
 
 from modules.account.account_service import AccountService
-from modules.account.types import AccountSearchParams
+from modules.account.types import AccountSearchParams, PhoneNumber
 from modules.authentication.authentication_service import AuthenticationService
 from modules.authentication.types import (
     CreateAccessTokenParams,
     EmailBasedAuthAccessTokenRequestParams,
     OTPBasedAuthAccessTokenRequestParams,
-    PhoneNumber,
 )
 
 

--- a/src/apps/backend/modules/config/config_service.py
+++ b/src/apps/backend/modules/config/config_service.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, cast
+from typing import Generic, Optional
 
 from modules.config.errors import MissingKeyError
 from modules.config.internals.config_manager import ConfigManager
@@ -13,7 +13,7 @@ class ConfigService(Generic[ConfigType]):
         value: Optional[ConfigType] = cls.config_manager.get(key, default=default)
         if value is None:
             raise MissingKeyError(missing_key=key, error_code=ErrorCode.MISSING_KEY)
-        return cast(ConfigType, value)
+        return value
 
     @classmethod
     def has_value(cls, key: str) -> bool:

--- a/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
+++ b/src/apps/backend/modules/config/internals/config_files/custom_env_config_file.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Optional, cast
+from typing import Any, Callable, Optional, cast
 
 from modules.config.internals.config_utils import ConfigUtil
 from modules.config.internals.types import Config
@@ -58,7 +58,7 @@ class CustomEnvConfig:
         if value is None:
             return None
 
-        parsers = {
+        parsers: dict[str, Callable[[str], int | float | bool]] = {
             "boolean": lambda x: x.lower() in ["true", "1"],
             "number": lambda x: int(x) if x.isdigit() else float(x),
         }

--- a/src/apps/backend/modules/config/internals/types.py
+++ b/src/apps/backend/modules/config/internals/types.py
@@ -1,5 +1,7 @@
 from typing import Dict, Union
 
-AllowedConfigValueTypes = Union[int, str, bool, float, list, Dict[str, "AllowedConfigValueTypes"], None, "Config"]
+AllowedConfigValueTypes = Union[
+    int, str, bool, float, list["AllowedConfigValueTypes"], Dict[str, "AllowedConfigValueTypes"], None, "Config"
+]
 
 Config = Dict[str, AllowedConfigValueTypes]

--- a/src/apps/backend/modules/config/types.py
+++ b/src/apps/backend/modules/config/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Any, TypeVar
 
-ConfigType = TypeVar("ConfigType", bound=bool | dict | float | int | list | str)
+ConfigType = TypeVar("ConfigType", bound=bool | dict[str, Any] | float | int | list[Any] | str)
 
 
 @dataclass(frozen=True)

--- a/src/apps/backend/modules/logger/internal/datadog_handler.py
+++ b/src/apps/backend/modules/logger/internal/datadog_handler.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from logging import LogRecord, StreamHandler
+from typing import TextIO
 
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.v2.api.logs_api import LogsApi
@@ -9,7 +10,7 @@ from datadog_api_client.v2.models import HTTPLog, HTTPLogItem
 from modules.config.config_service import ConfigService
 
 
-class DatadogHandler(StreamHandler):
+class DatadogHandler(StreamHandler[TextIO]):
     def __init__(self, ddsource: str) -> None:
         StreamHandler.__init__(self)
         self.ddsource = ddsource

--- a/src/apps/backend/modules/notification/internals/store/account_notification_preferences_model.py
+++ b/src/apps/backend/modules/notification/internals/store/account_notification_preferences_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -16,7 +16,7 @@ class AccountNotificationPreferencesModel(BaseModel):
     active: bool = True
 
     @classmethod
-    def from_bson(cls, bson_data: dict) -> "AccountNotificationPreferencesModel":
+    def from_bson(cls, bson_data: dict[str, Any]) -> "AccountNotificationPreferencesModel":
         return cls(
             account_id=str(bson_data.get("account_id")),
             id=bson_data.get("_id"),

--- a/src/apps/backend/modules/task/internal/store/task_model.py
+++ b/src/apps/backend/modules/task/internal/store/task_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from bson import ObjectId
 
@@ -15,7 +15,7 @@ class TaskModel(BaseModel):
     id: Optional[ObjectId | str] = None
 
     @classmethod
-    def from_bson(cls, bson_data: dict) -> "TaskModel":
+    def from_bson(cls, bson_data: dict[str, Any]) -> "TaskModel":
         return cls(
             account_id=bson_data.get("account_id", ""),
             active=bson_data.get("active", True),

--- a/src/apps/backend/mypy.ini
+++ b/src/apps/backend/mypy.ini
@@ -1,14 +1,30 @@
 [mypy]
-disallow_untyped_defs = True
-disallow_any_unimported = False
-no_implicit_optional = True
-check_untyped_defs = True
-warn_return_any = True
+strict = True
 show_error_codes = True
-warn_unused_ignores = True
-exclude = tests
+
+[mypy-bson.*]
 ignore_missing_imports = True
 
-# TODO: `ignore_missing_imports` is set to True to bypass issues with third-party library typings.
-# `disallow_any_unimported` is set to False to prevent errors with imports lacking stubs.
-# `ignore_missing_imports` should be removed and `disallow_any_unimported` must be set to False once the issues are resolved.
+[mypy-pymongo.*]
+ignore_missing_imports = True
+
+[mypy-celery.*]
+ignore_missing_imports = True
+
+[mypy-gunicorn.*]
+ignore_missing_imports = True
+
+[mypy-sendgrid.*]
+ignore_missing_imports = True
+
+[mypy-twilio.*]
+ignore_missing_imports = True
+
+[mypy-modules.logger.internal.datadog_handler]
+disallow_untyped_calls = False
+
+[mypy-celery_app]
+disallow_untyped_decorators = False
+
+[mypy-modules.application.worker]
+disallow_untyped_decorators = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterator
+from typing import Iterator, cast
 
 import pytest
 from celery_app import app as celery_app
@@ -35,7 +35,7 @@ def _purge_broker_queues() -> None:
 
 def broker_queue_depth(name: str) -> int:
     with celery_app.connection_for_write() as connection:
-        return connection.default_channel._size(name)
+        return cast(int, connection.default_channel._size(name))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/modules/account/base_test_account.py
+++ b/tests/modules/account/base_test_account.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Callable
+from typing import Any, Callable
 
 from modules.account.account_service import AccountService
 from modules.account.internal.store.account_repository import AccountRepository
@@ -13,7 +13,7 @@ from modules.notification.internals.store.account_notification_preferences_repos
 
 
 class BaseTestAccount(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
         AccountRestApiServer.create()
         self.account = AccountService.create_account_by_username_and_password(
@@ -23,7 +23,7 @@ class BaseTestAccount(unittest.TestCase):
         )
         self.access_token = AuthenticationService.create_access_token_by_username_and_password(account=self.account)
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         OTPRepository.collection().delete_many({})

--- a/tests/modules/account/base_test_account.py
+++ b/tests/modules/account/base_test_account.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Callable
+from typing import Callable
 
 from modules.account.account_service import AccountService
 from modules.account.internal.store.account_repository import AccountRepository
@@ -13,7 +13,7 @@ from modules.notification.internals.store.account_notification_preferences_repos
 
 
 class BaseTestAccount(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
         AccountRestApiServer.create()
         self.account = AccountService.create_account_by_username_and_password(
@@ -23,7 +23,7 @@ class BaseTestAccount(unittest.TestCase):
         )
         self.access_token = AuthenticationService.create_access_token_by_username_and_password(account=self.account)
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         OTPRepository.collection().delete_many({})

--- a/tests/modules/account/test_account_api/test_account_get_api.py
+++ b/tests/modules/account/test_account_api/test_account_get_api.py
@@ -54,6 +54,7 @@ class TestAccountGetApi(BaseTestAccount):
             )
 
             assert response.status_code == 401
+            assert response.json is not None
             assert "Access token has expired. Please login again." in response.json.get("message", "")
             assert response.json.get("code") == AccessTokenErrorCode.ACCESS_TOKEN_EXPIRED
 

--- a/tests/modules/account/test_account_api/test_account_post_api.py
+++ b/tests/modules/account/test_account_api/test_account_post_api.py
@@ -1,5 +1,6 @@
 import json
 from unittest import mock
+from unittest.mock import MagicMock
 
 from server import app
 
@@ -58,7 +59,7 @@ class TestAccountPostApi(BaseTestAccount):
 
     @mock.patch.object(SMSService, "send_sms_for_account")
     def test_given_new_phone_number_when_creating_account_then_creates_account_and_sends_one_time_password(
-        self, mock_send_sms
+        self, mock_send_sms: MagicMock
     ) -> None:
         request_body = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "9999999999"}})
 
@@ -66,6 +67,7 @@ class TestAccountPostApi(BaseTestAccount):
             response = client.post(ACCOUNT_URL, headers=HEADERS, data=request_body)
 
             assert response.status_code == 201
+            assert response.json is not None
             assert response.json.get("phone_number") == {"country_code": "+91", "phone_number": "9999999999"}
             assert "id" in response.json
             assert mock_send_sms.called
@@ -79,7 +81,7 @@ class TestAccountPostApi(BaseTestAccount):
 
     @mock.patch.object(SMSService, "send_sms_for_account")
     def test_given_existing_phone_number_when_creating_account_then_returns_account_and_sends_one_time_password(
-        self, mock_send_sms
+        self, mock_send_sms: MagicMock
     ) -> None:
         AccountService.get_or_create_account_by_phone_number(
             params=CreateAccountByPhoneNumberParams(
@@ -95,6 +97,7 @@ class TestAccountPostApi(BaseTestAccount):
             )
 
             assert response.status_code == 201
+            assert response.json is not None
             assert response.json.get("phone_number") == {"country_code": "+91", "phone_number": "9999999999"}
             assert "id" in response.json
             assert mock_send_sms.called
@@ -107,7 +110,9 @@ class TestAccountPostApi(BaseTestAccount):
             )
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_given_invalid_phone_number_when_creating_account_then_returns_bad_request(self, mock_send_sms) -> None:
+    def test_given_invalid_phone_number_when_creating_account_then_returns_bad_request(
+        self, mock_send_sms: MagicMock
+    ) -> None:
         request_body = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "999999999"}})
 
         with app.test_client() as client:

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from server import app
 
@@ -30,7 +30,7 @@ class TestAccountService(BaseTestAccount):
         assert account.last_name == "last_name"
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_get_account_by_id(self, mock_verify_access_token) -> None:
+    def test_get_account_by_id(self, mock_verify_access_token: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -47,7 +47,7 @@ class TestAccountService(BaseTestAccount):
         assert get_account_by_id.last_name == account.last_name
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_throw_exception_when_usernot_exist(self, mock_verify_access_token) -> None:
+    def test_throw_exception_when_usernot_exist(self, mock_verify_access_token: MagicMock) -> None:
         try:
             mock_verify_access_token.return_value = AccessTokenPayload(account_id="5f7b1b7b4f3b9b1b3f3b9b1b")
             with app.test_request_context():

--- a/tests/modules/account/test_notification_preferences_service.py
+++ b/tests/modules/account/test_notification_preferences_service.py
@@ -223,7 +223,7 @@ class TestNotificationPreferencesService(BaseTestAccount):
         assert preferences.push_enabled is False
         assert preferences.sms_enabled is False
 
-    def test_account_creation_by_username_automatically_creates_notification_preferences(self):
+    def test_account_creation_by_username_automatically_creates_notification_preferences(self) -> None:
         """Test that creating an account by username automatically creates notification preferences"""
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
@@ -238,7 +238,7 @@ class TestNotificationPreferencesService(BaseTestAccount):
         assert preferences.push_enabled is True
         assert preferences.sms_enabled is True
 
-    def test_account_creation_by_phone_automatically_creates_notification_preferences(self):
+    def test_account_creation_by_phone_automatically_creates_notification_preferences(self) -> None:
         phone_number = PhoneNumber(country_code="+91", phone_number="9999999999")
         account = AccountService.get_or_create_account_by_phone_number(
             params=CreateAccountByPhoneNumberParams(phone_number=phone_number)

--- a/tests/modules/application/base_test_application.py
+++ b/tests/modules/application/base_test_application.py
@@ -1,10 +1,10 @@
 import unittest
-from typing import Any, Callable
+from typing import Callable
 
 
 class BaseTestApplication(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")

--- a/tests/modules/application/base_test_application.py
+++ b/tests/modules/application/base_test_application.py
@@ -1,10 +1,10 @@
 import unittest
-from typing import Callable
+from typing import Any, Callable
 
 
 class BaseTestApplication(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")

--- a/tests/modules/application/test_security_headers.py
+++ b/tests/modules/application/test_security_headers.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from flask import Flask
+from flask.testing import FlaskClient
 
 from modules.application.internals.security_headers import SecurityHeaders
 
@@ -17,7 +18,7 @@ STRICT_CSP = (
 )
 
 
-def _build_client(*, behind_proxy: bool = False, config_overrides: Optional[Dict[str, object]] = None):
+def _build_client(*, behind_proxy: bool = False, config_overrides: Optional[Dict[str, object]] = None) -> FlaskClient:
     overrides = config_overrides or {}
 
     def _fake_get_value(key: str, default: object = None) -> object:
@@ -125,7 +126,7 @@ class TestGivenProxyFlagIsReadOnce:
 class TestGivenCorsIsConfigured:
     class TestWhenReadingCorsOrigin:
         @patch("modules.config.config_service.ConfigService.get_value")
-        def test_then_origin_reflects_config_and_is_not_wildcard(self, mock_get_value) -> None:
+        def test_then_origin_reflects_config_and_is_not_wildcard(self, mock_get_value: MagicMock) -> None:
             from modules.config.config_service import ConfigService
 
             mock_get_value.return_value = "https://app.example.com"

--- a/tests/modules/authentication/base_test_access_token.py
+++ b/tests/modules/authentication/base_test_access_token.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Callable
+from typing import Callable
 
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.authentication.internals.otp.store.otp_repository import OTPRepository
@@ -7,11 +7,11 @@ from modules.authentication.rest_api.authentication_rest_api_server import Authe
 
 
 class BaseTestAccessToken(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
         AuthenticationRestApiServer.create()
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         OTPRepository.collection().delete_many({})

--- a/tests/modules/authentication/base_test_access_token.py
+++ b/tests/modules/authentication/base_test_access_token.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Callable
+from typing import Any, Callable
 
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.authentication.internals.otp.store.otp_repository import OTPRepository
@@ -7,11 +7,11 @@ from modules.authentication.rest_api.authentication_rest_api_server import Authe
 
 
 class BaseTestAccessToken(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
         AuthenticationRestApiServer.create()
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         OTPRepository.collection().delete_many({})

--- a/tests/modules/authentication/base_test_password_reset_token.py
+++ b/tests/modules/authentication/base_test_password_reset_token.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Callable
+from typing import Callable
 
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.authentication.internals.password_reset_token.store.password_reset_token_repository import (
@@ -9,11 +9,11 @@ from modules.authentication.rest_api.authentication_rest_api_server import Authe
 
 
 class BaseTestPasswordResetToken(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
         AuthenticationRestApiServer.create()
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         PasswordResetTokenRepository.collection().delete_many({})

--- a/tests/modules/authentication/base_test_password_reset_token.py
+++ b/tests/modules/authentication/base_test_password_reset_token.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Callable
+from typing import Any, Callable
 
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.authentication.internals.password_reset_token.store.password_reset_token_repository import (
@@ -9,11 +9,11 @@ from modules.authentication.rest_api.authentication_rest_api_server import Authe
 
 
 class BaseTestPasswordResetToken(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
         AuthenticationRestApiServer.create()
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")
         AccountRepository.collection().delete_many({})
         PasswordResetTokenRepository.collection().delete_many({})

--- a/tests/modules/authentication/test_access_auth_middleware.py
+++ b/tests/modules/authentication/test_access_auth_middleware.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from flask import request
 from server import app
 
 from modules.authentication.errors import (
@@ -18,7 +17,7 @@ TEST_TOKEN = "your_test_token"
 
 class TestAccessAuthMiddleware(unittest.TestCase):
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_missing_authorization_header(self, mock_verify_access_token):
+    def test_missing_authorization_header(self, mock_verify_access_token: MagicMock) -> None:
         mock_next_func = MagicMock()
 
         with app.test_request_context():
@@ -28,34 +27,32 @@ class TestAccessAuthMiddleware(unittest.TestCase):
         mock_next_func.assert_not_called()
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_invalid_authorization_header(self, mock_verify_access_token):
+    def test_invalid_authorization_header(self, mock_verify_access_token: MagicMock) -> None:
         mock_next_func = MagicMock()
 
-        with app.test_request_context():
-            request.headers = {"Authorization": f"JWT {TEST_TOKEN}"}
+        with app.test_request_context(headers={"Authorization": f"JWT {TEST_TOKEN}"}):
             with self.assertRaises(InvalidAuthorizationHeaderError):
                 access_auth_middleware(mock_next_func)()
 
         mock_next_func.assert_not_called()
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_invalid_access_token(self, mock_verify_access_token):
+    def test_invalid_access_token(self, mock_verify_access_token: MagicMock) -> None:
         mock_next_func = MagicMock()
         mock_verify_access_token.side_effect = AccessTokenInvalidError("Invalid access token.")
 
-        with app.test_request_context():
-            request.headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
+        with app.test_request_context(headers={"Authorization": f"Bearer {TEST_TOKEN}"}):
             with self.assertRaises(AccessTokenInvalidError):
                 access_auth_middleware(mock_next_func)()
 
         mock_next_func.assert_not_called()
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_unauthorized_access(self, mock_verify_access_token):
+    def test_unauthorized_access(self, mock_verify_access_token: MagicMock) -> None:
         mock_verify_access_token.return_value = MagicMock(account_id="12345")
 
         @access_auth_middleware
-        def test_view_func(account_id):
+        def test_view_func(account_id: str) -> str:
             return account_id
 
         with app.test_request_context(headers={"Authorization": f"Bearer {TEST_TOKEN}"}):
@@ -63,7 +60,7 @@ class TestAccessAuthMiddleware(unittest.TestCase):
                 test_view_func(account_id="67890")
 
     @patch("modules.authentication.authentication_service.AuthenticationService.verify_access_token")
-    def test_expired_access_token(self, mock_verify_access_token):
+    def test_expired_access_token(self, mock_verify_access_token: MagicMock) -> None:
         mock_next_func = MagicMock()
         mock_verify_access_token.side_effect = AccessTokenExpiredError("Access token has expired. Please login again.")
 

--- a/tests/modules/authentication/test_access_token_api.py
+++ b/tests/modules/authentication/test_access_token_api.py
@@ -191,7 +191,7 @@ class TestAccessTokenApi(BaseTestAccessToken):
             assert response.json.get("code") == OTPErrorCode.OTP_EXPIRED
             assert response.json.get("message") == "The OTP has expired. Please request a new OTP."
 
-    def test_otp_based_auth_flow_with_disabled_sms_preferences(self):
+    def test_otp_based_auth_flow_with_disabled_sms_preferences(self) -> None:
         """Test complete OTP authentication flow works with disabled SMS preferences"""
         phone_number = {"country_code": "+91", "phone_number": "9999999999"}
 

--- a/tests/modules/authentication/test_access_token_signing_key.py
+++ b/tests/modules/authentication/test_access_token_signing_key.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Optional
+from typing import Callable, Iterator, Optional
 
 from modules.authentication.authentication_service import AuthenticationService
 from modules.authentication.errors import AccessTokenSigningKeyInsecureError
@@ -33,10 +33,10 @@ def _environment(app_env: str, signing_key: Optional[str]) -> Iterator[None]:
 
 
 class TestAccessTokenSigningKey(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")
 
     def test_deployed_env_without_signing_key_refuses_boot(self) -> None:

--- a/tests/modules/authentication/test_access_token_signing_key.py
+++ b/tests/modules/authentication/test_access_token_signing_key.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from contextlib import contextmanager
-from typing import Callable, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from modules.authentication.authentication_service import AuthenticationService
 from modules.authentication.errors import AccessTokenSigningKeyInsecureError
@@ -33,10 +33,10 @@ def _environment(app_env: str, signing_key: Optional[str]) -> Iterator[None]:
 
 
 class TestAccessTokenSigningKey(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")
 
     def test_deployed_env_without_signing_key_refuses_boot(self) -> None:

--- a/tests/modules/authentication/test_otp_whitelist_api.py
+++ b/tests/modules/authentication/test_otp_whitelist_api.py
@@ -1,6 +1,7 @@
 import json
 import os
 from unittest import mock
+from unittest.mock import MagicMock
 
 from server import app
 
@@ -19,14 +20,14 @@ HEADERS = {"Content-Type": "application/json"}
 
 class TestOTPWhitelistApi(BaseTestAccessToken):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.original_env = {}
         env_vars = ["DEFAULT_OTP_ENABLED", "DEFAULT_OTP_CODE", "DEFAULT_OTP_WHITELISTED_PHONE_NUMBER", "SMS_ENABLED"]
         for var in env_vars:
             self.original_env[var] = os.environ.get(var)
         self.original_config_manager = ConfigService.config_manager
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for var, value in self.original_env.items():
             if value is None:
                 os.environ.pop(var, None)
@@ -34,11 +35,11 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
                 os.environ[var] = value
         ConfigService.config_manager = self.original_config_manager
 
-    def _reload_config(self):
+    def _reload_config(self) -> None:
         ConfigService.config_manager = ConfigManager()
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_default_otp_disabled_matching_whitelist_sends_sms(self, mock_send_sms):
+    def test_default_otp_disabled_matching_whitelist_sends_sms(self, mock_send_sms: MagicMock) -> None:
         """When default OTP is disabled and phone matches whitelist, should still send SMS with random OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -48,13 +49,14 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         payload = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "9999999999"}})
         with app.test_client() as client:
             response = client.post(ACCOUNT_URL, headers=HEADERS, data=payload)
+            assert response.json is not None
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json.get("phone_number"), {"country_code": "+91", "phone_number": "9999999999"})
             self.assertIn("id", response.json)
             self.assertTrue(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_default_otp_disabled_non_matching_whitelist_sends_sms(self, mock_send_sms):
+    def test_default_otp_disabled_non_matching_whitelist_sends_sms(self, mock_send_sms: MagicMock) -> None:
         """When default OTP is disabled and phone doesn't match whitelist, should send SMS with random OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -64,13 +66,14 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         payload = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "8888888888"}})
         with app.test_client() as client:
             response = client.post(ACCOUNT_URL, headers=HEADERS, data=payload)
+            assert response.json is not None
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json.get("phone_number"), {"country_code": "+91", "phone_number": "8888888888"})
             self.assertIn("id", response.json)
             self.assertTrue(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_default_otp_enabled_matching_whitelist_no_sms(self, mock_send_sms):
+    def test_default_otp_enabled_matching_whitelist_no_sms(self, mock_send_sms: MagicMock) -> None:
         """When default OTP is enabled and phone matches whitelist, should not send SMS"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -80,13 +83,14 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         payload = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "9999999999"}})
         with app.test_client() as client:
             response = client.post(ACCOUNT_URL, headers=HEADERS, data=payload)
+            assert response.json is not None
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json.get("phone_number"), {"country_code": "+91", "phone_number": "9999999999"})
             self.assertIn("id", response.json)
             self.assertFalse(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_default_otp_enabled_non_matching_whitelist_sends_sms(self, mock_send_sms):
+    def test_default_otp_enabled_non_matching_whitelist_sends_sms(self, mock_send_sms: MagicMock) -> None:
         """When default OTP is enabled and phone doesn't match whitelist, should send SMS with random OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -96,6 +100,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         payload = json.dumps({"phone_number": {"country_code": "+91", "phone_number": "8888888888"}})
         with app.test_client() as client:
             response = client.post(ACCOUNT_URL, headers=HEADERS, data=payload)
+            assert response.json is not None
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response.json.get("phone_number"), {"country_code": "+91", "phone_number": "8888888888"})
             self.assertIn("id", response.json)
@@ -106,7 +111,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
             )
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_create_otp_directly_default_enabled_matching_whitelist(self, mock_send_sms):
+    def test_create_otp_directly_default_enabled_matching_whitelist(self, mock_send_sms: MagicMock) -> None:
         """When calling create_otp directly with enabled default OTP and matching whitelist, should not send SMS"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -123,7 +128,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         self.assertFalse(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_create_otp_directly_default_enabled_non_matching_whitelist(self, mock_send_sms):
+    def test_create_otp_directly_default_enabled_non_matching_whitelist(self, mock_send_sms: MagicMock) -> None:
         """When calling create_otp directly with enabled default OTP and non-matching whitelist, should send SMS"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -142,7 +147,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         self.assertTrue(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_create_otp_directly_default_disabled(self, mock_send_sms):
+    def test_create_otp_directly_default_disabled(self, mock_send_sms: MagicMock) -> None:
         """When calling create_otp directly with disabled default OTP, should always send SMS"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -161,7 +166,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         self.assertTrue(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_empty_string_whitelist_treated_as_no_whitelist(self, mock_send_sms):
+    def test_empty_string_whitelist_treated_as_no_whitelist(self, mock_send_sms: MagicMock) -> None:
         """When whitelist is empty string, should treat as no whitelist (use default OTP for all)"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -178,7 +183,7 @@ class TestOTPWhitelistApi(BaseTestAccessToken):
         self.assertFalse(mock_send_sms.called)
 
     @mock.patch.object(SMSService, "send_sms_for_account")
-    def test_otp_creation_uses_bypass_preferences(self, mock_send_sms):
+    def test_otp_creation_uses_bypass_preferences(self, mock_send_sms: MagicMock) -> None:
         """Test that OTP creation uses bypass_preferences=True for SMS"""
         phone_number = PhoneNumber(country_code="+91", phone_number="9999999999")
         account = AccountService.get_or_create_account_by_phone_number(

--- a/tests/modules/authentication/test_otp_whitelist_service.py
+++ b/tests/modules/authentication/test_otp_whitelist_service.py
@@ -8,7 +8,7 @@ from tests.modules.authentication.base_test_access_token import BaseTestAccessTo
 
 class TestOTPWhitelistService(BaseTestAccessToken):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.original_env = {}
         env_vars = ["DEFAULT_OTP_ENABLED", "DEFAULT_OTP_CODE", "DEFAULT_OTP_WHITELISTED_PHONE_NUMBER"]
         for var in env_vars:
@@ -16,7 +16,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
 
         self.original_config_manager = ConfigService.config_manager
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for var, value in self.original_env.items():
             if value is None:
                 os.environ.pop(var, None)
@@ -25,10 +25,10 @@ class TestOTPWhitelistService(BaseTestAccessToken):
 
         ConfigService.config_manager = self.original_config_manager
 
-    def _reload_config(self):
+    def _reload_config(self) -> None:
         ConfigService.config_manager = ConfigManager()
 
-    def test_default_otp_disabled_with_whitelist_matching_should_use_random(self):
+    def test_default_otp_disabled_with_whitelist_matching_should_use_random(self) -> None:
         """When default OTP is disabled and phone matches whitelist, should still use random OTP (send SMS)"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -38,7 +38,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         result = OTPUtil.should_use_default_otp_for_phone_number("9999999999")
         self.assertFalse(result)
 
-    def test_default_otp_disabled_with_whitelist_non_matching_should_use_random(self):
+    def test_default_otp_disabled_with_whitelist_non_matching_should_use_random(self) -> None:
         """When default OTP is disabled and phone doesn't match whitelist, should use random OTP (send SMS)"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -48,7 +48,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         result = OTPUtil.should_use_default_otp_for_phone_number("8888888888")
         self.assertFalse(result)
 
-    def test_default_otp_enabled_empty_string_whitelist_should_use_default(self):
+    def test_default_otp_enabled_empty_string_whitelist_should_use_default(self) -> None:
         """When default OTP is enabled and whitelist is empty string, should use default OTP (no SMS)"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -58,7 +58,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         result = OTPUtil.should_use_default_otp_for_phone_number("9999999999")
         self.assertTrue(result)
 
-    def test_default_otp_enabled_with_whitelist_matching_should_use_default(self):
+    def test_default_otp_enabled_with_whitelist_matching_should_use_default(self) -> None:
         """When default OTP is enabled and phone matches whitelist, should use default OTP (no SMS)"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -68,7 +68,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         result = OTPUtil.should_use_default_otp_for_phone_number("9999999999")
         self.assertTrue(result)
 
-    def test_default_otp_enabled_with_whitelist_non_matching_should_use_random(self):
+    def test_default_otp_enabled_with_whitelist_non_matching_should_use_random(self) -> None:
         """When default OTP is enabled and phone doesn't match whitelist, should use random OTP (send SMS)"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -78,7 +78,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         result = OTPUtil.should_use_default_otp_for_phone_number("8888888888")
         self.assertFalse(result)
 
-    def test_generate_otp_uses_default_when_should_use_default_is_true(self):
+    def test_generate_otp_uses_default_when_should_use_default_is_true(self) -> None:
         """When should_use_default_otp_for_phone_number returns True, generate_otp should return default OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -88,7 +88,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         otp = OTPUtil.generate_otp(length=4, phone_number="9999999999")
         self.assertEqual(otp, "1234")
 
-    def test_generate_otp_uses_random_when_should_use_default_is_false(self):
+    def test_generate_otp_uses_random_when_should_use_default_is_false(self) -> None:
         """When should_use_default_otp_for_phone_number returns False, generate_otp should return random OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = "true"
         os.environ["DEFAULT_OTP_CODE"] = "1234"
@@ -100,7 +100,7 @@ class TestOTPWhitelistService(BaseTestAccessToken):
         self.assertEqual(len(otp), 4)
         self.assertTrue(otp.isdigit())
 
-    def test_generate_otp_uses_random_when_default_otp_disabled(self):
+    def test_generate_otp_uses_random_when_default_otp_disabled(self) -> None:
         """When default OTP is disabled, generate_otp should always return random OTP"""
         os.environ["DEFAULT_OTP_ENABLED"] = ""
         os.environ["DEFAULT_OTP_CODE"] = "1234"

--- a/tests/modules/authentication/test_password_reset_token_api.py
+++ b/tests/modules/authentication/test_password_reset_token_api.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime, timedelta
 from unittest import mock
+from unittest.mock import MagicMock
 
 from server import app
 
@@ -25,7 +26,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
     # POST /password-reset-tokens tests
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_create_password_reset_token(self, mock_send_email) -> None:
+    def test_create_password_reset_token(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -36,6 +37,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
         with app.test_client() as client:
             response = client.post(PASSWORD_RESET_TOKEN_URL, headers=HEADERS, data=json.dumps(reset_password_params))
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 201)
             self.assertTrue(response.json)
@@ -49,7 +51,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
     @mock.patch.object(EmailService, "send_email_for_account")
     def test_given_account_when_creating_password_reset_token_then_created_at_and_updated_at_reflect_creation_time(
-        self, mock_send_email
+        self, mock_send_email: MagicMock
     ) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
@@ -114,12 +116,13 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
         assert used_password_reset_token.updated_at > used_password_reset_token.created_at
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_create_password_reset_token_account_not_found(self, mock_send_email):
+    def test_create_password_reset_token_account_not_found(self, mock_send_email: MagicMock) -> None:
         username = "nonexistent_username@example.com"
         reset_password_params = {"username": username}
 
         with app.test_client() as client:
             response = client.post(PASSWORD_RESET_TOKEN_URL, headers=HEADERS, data=json.dumps(reset_password_params))
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 404)
             self.assertIn("message", response.json)
@@ -133,7 +136,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
     # PATCH /account/:account_id tests
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_reset_account_password(self, mock_send_email):
+    def test_reset_account_password(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -152,6 +155,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account.id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 200)
             self.assertIn("id", response.json)
@@ -165,7 +169,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertTrue(mock_send_email.called)
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_reset_account_password_account_not_found(self, mock_send_email):
+    def test_reset_account_password_account_not_found(self, mock_send_email: MagicMock) -> None:
         account_id = "661e42ec98423703a299a899"
         new_password = "new_password"
         token = "token"
@@ -176,6 +180,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account_id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 404)
             self.assertIn("message", response.json)
@@ -188,7 +193,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertFalse(mock_send_email.called)
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_reset_account_password_token_not_found(self, mock_send_email):
+    def test_reset_account_password_token_not_found(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -204,6 +209,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account.id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 404)
             self.assertIn("message", response.json)
@@ -211,7 +217,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertFalse(mock_send_email.called)
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_reset_account_password_token_already_used(self, mock_send_email):
+    def test_reset_account_password_token_already_used(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -230,6 +236,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account.id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 400)
             self.assertIn("message", response.json)
@@ -242,7 +249,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertTrue(mock_send_email.called)
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_reset_account_password_invalid_token(self, mock_send_email):
+    def test_reset_account_password_invalid_token(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -259,6 +266,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account.id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 400)
             self.assertIn("message", response.json)
@@ -272,7 +280,9 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
     @mock.patch.object(EmailService, "send_email_for_account")
     @mock.patch.object(PasswordResetTokenUtil, "is_token_expired")
-    def test_reset_account_password_expired_token(self, mock_is_token_expired, mock_send_email):
+    def test_reset_account_password_expired_token(
+        self, mock_is_token_expired: MagicMock, mock_send_email: MagicMock
+    ) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -291,6 +301,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             response = client.patch(
                 f"{ACCOUNT_API_URL}/{account.id}", headers=HEADERS, data=json.dumps(reset_password_params)
             )
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 400)
             self.assertIn("message", response.json)
@@ -303,7 +314,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
             self.assertTrue(mock_send_email.called)
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_password_reset_email_uses_bypass_preferences(self, mock_send_email):
+    def test_password_reset_email_uses_bypass_preferences(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="Test", last_name="User", password="password123", username="testuser@example.com"
@@ -321,7 +332,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
         assert call_kwargs["account_id"] == account.id
 
     @mock.patch.object(EmailService, "send_email_for_account")
-    def test_password_reset_flow_with_disabled_email_preferences(self, mock_send_email):
+    def test_password_reset_flow_with_disabled_email_preferences(self, mock_send_email: MagicMock) -> None:
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="Test", last_name="User", password="old_password", username="testuser@example.com"
@@ -336,6 +347,7 @@ class TestAccountPasswordReset(BaseTestPasswordResetToken):
 
         with app.test_client() as client:
             response = client.post(PASSWORD_RESET_TOKEN_URL, headers=HEADERS, data=json.dumps(reset_password_params))
+            assert response.json is not None
 
             self.assertEqual(response.status_code, 201)
             self.assertTrue(response.json)

--- a/tests/modules/config/base_test_config.py
+++ b/tests/modules/config/base_test_config.py
@@ -1,10 +1,10 @@
 import unittest
-from typing import Callable
+from typing import Any, Callable
 
 
 class BaseTestConfig(unittest.TestCase):
-    def setup_method(self, method: Callable) -> None:
+    def setup_method(self, method: Callable[..., Any]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable) -> None:
+    def teardown_method(self, method: Callable[..., Any]) -> None:
         print(f"Executed:: {method.__name__}")

--- a/tests/modules/config/base_test_config.py
+++ b/tests/modules/config/base_test_config.py
@@ -1,10 +1,10 @@
 import unittest
-from typing import Any, Callable
+from typing import Callable
 
 
 class BaseTestConfig(unittest.TestCase):
-    def setup_method(self, method: Callable[..., Any]) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         print(f"Executing:: {method.__name__}")
 
-    def teardown_method(self, method: Callable[..., Any]) -> None:
+    def teardown_method(self, method: Callable[..., object]) -> None:
         print(f"Executed:: {method.__name__}")

--- a/tests/modules/config/test_custom_env_config.py
+++ b/tests/modules/config/test_custom_env_config.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from modules.config.internals.config_files.custom_env_config_file import CustomEnvConfig
 from modules.config.internals.config_utils import ConfigUtil
+from modules.config.internals.types import Config
 from tests.modules.config.base_test_config import BaseTestConfig
 
 
@@ -18,7 +19,7 @@ class TestCustomEnvConfig(BaseTestConfig):
         assert "feature" not in overrides
 
     def test_unset_name_mapping_does_not_blank_base_value(self) -> None:
-        base_layer = {"feature": {"enabled": True}}
+        base_layer: Config = {"feature": {"enabled": True}}
         override_layer = CustomEnvConfig._apply_environment_overrides({"feature": {"__name": self.UNSET_ENV_VAR}})
 
         merged = ConfigUtil.deep_merge(base_layer, override_layer)

--- a/tests/modules/config/test_custom_env_config.py
+++ b/tests/modules/config/test_custom_env_config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Callable
 
 from modules.config.internals.config_files.custom_env_config_file import CustomEnvConfig
 from modules.config.internals.config_utils import ConfigUtil
@@ -10,7 +10,7 @@ from tests.modules.config.base_test_config import BaseTestConfig
 class TestCustomEnvConfig(BaseTestConfig):
     UNSET_ENV_VAR = "FLASK_REACT_TEMPLATE_TEST_UNSET_ENV_VAR"
 
-    def setup_method(self, method: Any) -> None:
+    def setup_method(self, method: Callable[..., object]) -> None:
         super().setup_method(method)
         os.environ.pop(self.UNSET_ENV_VAR, None)
 

--- a/tests/modules/task/base_test_task.py
+++ b/tests/modules/task/base_test_task.py
@@ -1,8 +1,9 @@
 import json
 import unittest
-from typing import Tuple
+from typing import Any, Optional, Tuple
 
 from server import app
+from werkzeug.test import TestResponse
 
 from modules.account.account_service import AccountService
 from modules.account.internal.store.account_repository import AccountRepository
@@ -42,7 +43,11 @@ class BaseTestTask(unittest.TestCase):
     # ACCOUNT AND TOKEN HELPER METHODS
 
     def create_test_account(
-        self, username: str = None, password: str = None, first_name: str = None, last_name: str = None
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
     ) -> Account:
         return AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
@@ -53,7 +58,7 @@ class BaseTestTask(unittest.TestCase):
             )
         )
 
-    def get_access_token(self, username: str = None, password: str = None) -> str:
+    def get_access_token(self, username: Optional[str] = None, password: Optional[str] = None) -> str:
         with app.test_client() as client:
             response = client.post(
                 self.ACCESS_TOKEN_URL,
@@ -62,9 +67,14 @@ class BaseTestTask(unittest.TestCase):
                     {"username": username or self.DEFAULT_USERNAME, "password": password or self.DEFAULT_PASSWORD}
                 ),
             )
-            return response.json.get("token")
+            assert response.json is not None
+            token = response.json.get("token")
+            assert isinstance(token, str)
+            return token
 
-    def create_account_and_get_token(self, username: str = None, password: str = None) -> Tuple[Account, str]:
+    def create_account_and_get_token(
+        self, username: Optional[str] = None, password: Optional[str] = None
+    ) -> Tuple[Account, str]:
         test_username = username or f"testuser_{id(self)}@example.com"
         test_password = password or self.DEFAULT_PASSWORD
 
@@ -74,7 +84,7 @@ class BaseTestTask(unittest.TestCase):
 
     # TASK HELPER METHODS
 
-    def create_test_task(self, account_id: str, title: str = None, description: str = None) -> Task:
+    def create_test_task(self, account_id: str, title: Optional[str] = None, description: Optional[str] = None) -> Task:
         return TaskService.create_task(
             params=CreateTaskParams(
                 account_id=account_id,
@@ -84,7 +94,7 @@ class BaseTestTask(unittest.TestCase):
         )
 
     def create_multiple_test_tasks(self, account_id: str, count: int) -> list[Task]:
-        tasks = []
+        tasks: list[Task] = []
         for i in range(count):
             task = self.create_test_task(account_id=account_id, title=f"Task {i+1}", description=f"Description {i+1}")
             tasks.append(task)
@@ -93,8 +103,14 @@ class BaseTestTask(unittest.TestCase):
     # HTTP REQUEST HELPER METHODS
 
     def make_authenticated_request(
-        self, method: str, account_id: str, token: str, task_id: str = None, data: dict = None, query_params: str = ""
-    ):
+        self,
+        method: str,
+        account_id: str,
+        token: str,
+        task_id: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+        query_params: str = "",
+    ) -> TestResponse:
         if task_id:
             url = self.get_task_by_id_api_url(account_id, task_id)
         else:
@@ -108,14 +124,17 @@ class BaseTestTask(unittest.TestCase):
         with app.test_client() as client:
             if method.upper() == "GET":
                 return client.get(url, headers={"Authorization": f"Bearer {token}"})
-            elif method.upper() == "POST":
+            if method.upper() == "POST":
                 return client.post(url, headers=headers, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "PATCH":
+            if method.upper() == "PATCH":
                 return client.patch(url, headers=headers, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "DELETE":
+            if method.upper() == "DELETE":
                 return client.delete(url, headers={"Authorization": f"Bearer {token}"})
+        raise ValueError(f"Unsupported method: {method}")
 
-    def make_unauthenticated_request(self, method: str, account_id: str, task_id: str = None, data: dict = None):
+    def make_unauthenticated_request(
+        self, method: str, account_id: str, task_id: Optional[str] = None, data: Optional[dict[str, Any]] = None
+    ) -> TestResponse:
         if task_id:
             url = self.get_task_by_id_api_url(account_id, task_id)
         else:
@@ -124,16 +143,22 @@ class BaseTestTask(unittest.TestCase):
         with app.test_client() as client:
             if method.upper() == "GET":
                 return client.get(url)
-            elif method.upper() == "POST":
+            if method.upper() == "POST":
                 return client.post(url, headers=self.HEADERS, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "PATCH":
+            if method.upper() == "PATCH":
                 return client.patch(url, headers=self.HEADERS, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "DELETE":
+            if method.upper() == "DELETE":
                 return client.delete(url)
+        raise ValueError(f"Unsupported method: {method}")
 
     def make_cross_account_request(
-        self, method: str, target_account_id: str, auth_token: str, task_id: str = None, data: dict = None
-    ):
+        self,
+        method: str,
+        target_account_id: str,
+        auth_token: str,
+        task_id: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> TestResponse:
         if task_id:
             url = self.get_task_by_id_api_url(target_account_id, task_id)
         else:
@@ -144,16 +169,19 @@ class BaseTestTask(unittest.TestCase):
         with app.test_client() as client:
             if method.upper() == "GET":
                 return client.get(url, headers={"Authorization": f"Bearer {auth_token}"})
-            elif method.upper() == "POST":
+            if method.upper() == "POST":
                 return client.post(url, headers=headers, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "PATCH":
+            if method.upper() == "PATCH":
                 return client.patch(url, headers=headers, data=json.dumps(data) if data is not None else None)
-            elif method.upper() == "DELETE":
+            if method.upper() == "DELETE":
                 return client.delete(url, headers={"Authorization": f"Bearer {auth_token}"})
+        raise ValueError(f"Unsupported method: {method}")
 
     # ASSERTION HELPER METHODS
 
-    def assert_task_response(self, response_json: dict, expected_task: Task = None, **expected_fields):
+    def assert_task_response(
+        self, response_json: dict[str, Any], expected_task: Optional[Task] = None, **expected_fields: Any
+    ) -> None:
         assert response_json.get("id") is not None
         assert response_json.get("account_id") is not None
 
@@ -166,7 +194,7 @@ class BaseTestTask(unittest.TestCase):
         for field, value in expected_fields.items():
             assert response_json.get(field) == value
 
-    def assert_error_response(self, response, expected_status: int, expected_error_code: str):
+    def assert_error_response(self, response: TestResponse, expected_status: int, expected_error_code: str) -> None:
         assert response.status_code == expected_status, f"Expected status {expected_status}, got {response.status_code}"
         assert response.json is not None, f"Expected JSON response, got None. Response data: {response.data}"
         assert (
@@ -175,12 +203,12 @@ class BaseTestTask(unittest.TestCase):
 
     def assert_pagination_response(
         self,
-        response_json: dict,
+        response_json: dict[str, Any],
         expected_items_count: int,
-        expected_total_count: int = None,
-        expected_page: int = None,
-        expected_size: int = None,
-    ):
+        expected_total_count: Optional[int] = None,
+        expected_page: Optional[int] = None,
+        expected_size: Optional[int] = None,
+    ) -> None:
         assert "items" in response_json
         assert "pagination_params" in response_json
         assert "total_count" in response_json

--- a/tests/modules/task/base_test_task.py
+++ b/tests/modules/task/base_test_task.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple, TypedDict
 
 from server import app
 from werkzeug.test import TestResponse
@@ -12,6 +12,29 @@ from modules.task.internal.store.task_repository import TaskRepository
 from modules.task.rest_api.task_rest_api_server import TaskRestApiServer
 from modules.task.task_service import TaskService
 from modules.task.types import CreateTaskParams, Task
+
+
+class TaskRequestBody(TypedDict, total=False):
+    title: str
+    description: str
+
+
+class TaskResponse(TypedDict, total=False):
+    id: str
+    account_id: str
+    title: str
+    description: str
+
+
+class PaginationParamsResponse(TypedDict):
+    page: int
+    size: int
+
+
+class PaginatedTasksResponse(TypedDict):
+    items: list[TaskResponse]
+    pagination_params: PaginationParamsResponse
+    total_count: int
 
 
 class BaseTestTask(unittest.TestCase):
@@ -108,7 +131,7 @@ class BaseTestTask(unittest.TestCase):
         account_id: str,
         token: str,
         task_id: Optional[str] = None,
-        data: Optional[dict[str, Any]] = None,
+        data: Optional[TaskRequestBody] = None,
         query_params: str = "",
     ) -> TestResponse:
         if task_id:
@@ -133,7 +156,7 @@ class BaseTestTask(unittest.TestCase):
         raise ValueError(f"Unsupported method: {method}")
 
     def make_unauthenticated_request(
-        self, method: str, account_id: str, task_id: Optional[str] = None, data: Optional[dict[str, Any]] = None
+        self, method: str, account_id: str, task_id: Optional[str] = None, data: Optional[TaskRequestBody] = None
     ) -> TestResponse:
         if task_id:
             url = self.get_task_by_id_api_url(account_id, task_id)
@@ -157,7 +180,7 @@ class BaseTestTask(unittest.TestCase):
         target_account_id: str,
         auth_token: str,
         task_id: Optional[str] = None,
-        data: Optional[dict[str, Any]] = None,
+        data: Optional[TaskRequestBody] = None,
     ) -> TestResponse:
         if task_id:
             url = self.get_task_by_id_api_url(target_account_id, task_id)
@@ -180,7 +203,14 @@ class BaseTestTask(unittest.TestCase):
     # ASSERTION HELPER METHODS
 
     def assert_task_response(
-        self, response_json: dict[str, Any], expected_task: Optional[Task] = None, **expected_fields: Any
+        self,
+        response_json: TaskResponse,
+        expected_task: Optional[Task] = None,
+        *,
+        id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> None:
         assert response_json.get("id") is not None
         assert response_json.get("account_id") is not None
@@ -191,8 +221,14 @@ class BaseTestTask(unittest.TestCase):
             assert response_json.get("title") == expected_task.title
             assert response_json.get("description") == expected_task.description
 
-        for field, value in expected_fields.items():
-            assert response_json.get(field) == value
+        if id is not None:
+            assert response_json.get("id") == id
+        if account_id is not None:
+            assert response_json.get("account_id") == account_id
+        if title is not None:
+            assert response_json.get("title") == title
+        if description is not None:
+            assert response_json.get("description") == description
 
     def assert_error_response(self, response: TestResponse, expected_status: int, expected_error_code: str) -> None:
         assert response.status_code == expected_status, f"Expected status {expected_status}, got {response.status_code}"
@@ -203,7 +239,7 @@ class BaseTestTask(unittest.TestCase):
 
     def assert_pagination_response(
         self,
-        response_json: dict[str, Any],
+        response_json: PaginatedTasksResponse,
         expected_items_count: int,
         expected_total_count: Optional[int] = None,
         expected_page: Optional[int] = None,

--- a/tests/modules/task/test_task_api.py
+++ b/tests/modules/task/test_task_api.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from server import app
 
 from modules.authentication.types import AccessTokenErrorCode
@@ -29,6 +31,7 @@ class TestTaskApi(BaseTestTask):
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
         self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert response.json is not None
         assert "Title is required" in response.json.get("message")
 
     def test_create_task_missing_description(self) -> None:
@@ -38,15 +41,17 @@ class TestTaskApi(BaseTestTask):
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
         self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert response.json is not None
         assert "Description is required" in response.json.get("message")
 
     def test_create_task_empty_body(self) -> None:
         account, token = self.create_account_and_get_token()
-        task_data = {}
+        task_data: dict[str, Any] = {}
 
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
         self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert response.json is not None
         assert "Title is required" in response.json.get("message")
 
     def test_create_task_no_auth(self) -> None:
@@ -72,6 +77,7 @@ class TestTaskApi(BaseTestTask):
         response = self.make_authenticated_request("GET", account.id, token)
 
         assert response.status_code == 200
+        assert response.json is not None
         self.assert_pagination_response(response.json, expected_items_count=0, expected_total_count=0)
 
     def test_get_all_tasks_with_tasks(self) -> None:
@@ -81,6 +87,7 @@ class TestTaskApi(BaseTestTask):
         response = self.make_authenticated_request("GET", account.id, token)
 
         assert response.status_code == 200
+        assert response.json is not None
         self.assert_pagination_response(response.json, expected_items_count=3, expected_total_count=3)
 
         assert response.json["items"][0]["title"] == "Task 3"
@@ -95,11 +102,13 @@ class TestTaskApi(BaseTestTask):
         response2 = self.make_authenticated_request("GET", account.id, token, query_params="page=2&size=2")
 
         assert response1.status_code == 200
+        assert response1.json is not None
         self.assert_pagination_response(
             response1.json, expected_items_count=2, expected_total_count=5, expected_page=1, expected_size=2
         )
 
         assert response2.status_code == 200
+        assert response2.json is not None
         self.assert_pagination_response(
             response2.json, expected_items_count=2, expected_total_count=5, expected_page=2, expected_size=2
         )
@@ -120,6 +129,7 @@ class TestTaskApi(BaseTestTask):
         response = self.make_authenticated_request("GET", account.id, token, task_id=created_task.id)
 
         assert response.status_code == 200
+        assert response.json is not None
         self.assert_task_response(response.json, expected_task=created_task)
 
     def test_get_specific_task_not_found(self) -> None:
@@ -150,6 +160,7 @@ class TestTaskApi(BaseTestTask):
         )
 
         assert response.status_code == 200
+        assert response.json is not None
         self.assert_task_response(
             response.json,
             id=created_task.id,
@@ -168,6 +179,7 @@ class TestTaskApi(BaseTestTask):
         )
 
         self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert response.json is not None
         assert "Title is required" in response.json.get("message")
 
     def test_update_task_missing_description(self) -> None:
@@ -180,6 +192,7 @@ class TestTaskApi(BaseTestTask):
         )
 
         self.assert_error_response(response, 400, TaskErrorCode.BAD_REQUEST)
+        assert response.json is not None
         assert "Description is required" in response.json.get("message")
 
     def test_update_task_not_found(self) -> None:
@@ -238,6 +251,7 @@ class TestTaskApi(BaseTestTask):
 
         task_data = {"title": "Account 1 Task", "description": "This belongs to account 1"}
         create_response = self.make_authenticated_request("POST", account1.id, token1, data=task_data)
+        assert create_response.json is not None
         account1_task_id = create_response.json.get("id")
 
         get_response = self.make_cross_account_request("GET", account1.id, token2, task_id=account1_task_id)
@@ -252,6 +266,7 @@ class TestTaskApi(BaseTestTask):
 
         verify_response = self.make_authenticated_request("GET", account1.id, token1, task_id=account1_task_id)
         assert verify_response.status_code == 200
+        assert verify_response.json is not None
         assert verify_response.json.get("id") == account1_task_id
 
     def test_invalid_json_request_body(self) -> None:

--- a/tests/modules/task/test_task_api.py
+++ b/tests/modules/task/test_task_api.py
@@ -1,17 +1,15 @@
-from typing import Any
-
 from server import app
 
 from modules.authentication.types import AccessTokenErrorCode
 from modules.task.types import TaskErrorCode
-from tests.modules.task.base_test_task import BaseTestTask
+from tests.modules.task.base_test_task import BaseTestTask, TaskRequestBody
 
 
 class TestTaskApi(BaseTestTask):
 
     def test_create_task_success(self) -> None:
         account, token = self.create_account_and_get_token()
-        task_data = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
+        task_data: TaskRequestBody = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
 
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
@@ -26,7 +24,7 @@ class TestTaskApi(BaseTestTask):
 
     def test_create_task_missing_title(self) -> None:
         account, token = self.create_account_and_get_token()
-        task_data = {"description": self.DEFAULT_TASK_DESCRIPTION}
+        task_data: TaskRequestBody = {"description": self.DEFAULT_TASK_DESCRIPTION}
 
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
@@ -36,7 +34,7 @@ class TestTaskApi(BaseTestTask):
 
     def test_create_task_missing_description(self) -> None:
         account, token = self.create_account_and_get_token()
-        task_data = {"title": self.DEFAULT_TASK_TITLE}
+        task_data: TaskRequestBody = {"title": self.DEFAULT_TASK_TITLE}
 
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
@@ -46,7 +44,7 @@ class TestTaskApi(BaseTestTask):
 
     def test_create_task_empty_body(self) -> None:
         account, token = self.create_account_and_get_token()
-        task_data: dict[str, Any] = {}
+        task_data: TaskRequestBody = {}
 
         response = self.make_authenticated_request("POST", account.id, token, data=task_data)
 
@@ -56,7 +54,7 @@ class TestTaskApi(BaseTestTask):
 
     def test_create_task_no_auth(self) -> None:
         account, _ = self.create_account_and_get_token()
-        task_data = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
+        task_data: TaskRequestBody = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
 
         response = self.make_unauthenticated_request("POST", account.id, data=task_data)
 
@@ -65,7 +63,7 @@ class TestTaskApi(BaseTestTask):
     def test_create_task_invalid_token(self) -> None:
         account, _ = self.create_account_and_get_token()
         invalid_token = "invalid_token"
-        task_data = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
+        task_data: TaskRequestBody = {"title": self.DEFAULT_TASK_TITLE, "description": self.DEFAULT_TASK_DESCRIPTION}
 
         response = self.make_authenticated_request("POST", account.id, invalid_token, data=task_data)
 
@@ -153,7 +151,7 @@ class TestTaskApi(BaseTestTask):
         created_task = self.create_test_task(
             account_id=account.id, title="Original Title", description="Original Description"
         )
-        update_data = {"title": "Updated Title", "description": "Updated Description"}
+        update_data: TaskRequestBody = {"title": "Updated Title", "description": "Updated Description"}
 
         response = self.make_authenticated_request(
             "PATCH", account.id, token, task_id=created_task.id, data=update_data
@@ -172,7 +170,7 @@ class TestTaskApi(BaseTestTask):
     def test_update_task_missing_title(self) -> None:
         account, token = self.create_account_and_get_token()
         created_task = self.create_test_task(account_id=account.id)
-        update_data = {"description": "Updated Description"}
+        update_data: TaskRequestBody = {"description": "Updated Description"}
 
         response = self.make_authenticated_request(
             "PATCH", account.id, token, task_id=created_task.id, data=update_data
@@ -185,7 +183,7 @@ class TestTaskApi(BaseTestTask):
     def test_update_task_missing_description(self) -> None:
         account, token = self.create_account_and_get_token()
         created_task = self.create_test_task(account_id=account.id)
-        update_data = {"title": "Updated Title"}
+        update_data: TaskRequestBody = {"title": "Updated Title"}
 
         response = self.make_authenticated_request(
             "PATCH", account.id, token, task_id=created_task.id, data=update_data
@@ -198,7 +196,7 @@ class TestTaskApi(BaseTestTask):
     def test_update_task_not_found(self) -> None:
         account, token = self.create_account_and_get_token()
         non_existent_task_id = "507f1f77bcf86cd799439011"
-        update_data = {"title": "Updated Title", "description": "Updated Description"}
+        update_data: TaskRequestBody = {"title": "Updated Title", "description": "Updated Description"}
 
         response = self.make_authenticated_request(
             "PATCH", account.id, token, task_id=non_existent_task_id, data=update_data
@@ -209,7 +207,7 @@ class TestTaskApi(BaseTestTask):
     def test_update_task_no_auth(self) -> None:
         account, _ = self.create_account_and_get_token()
         fake_task_id = "507f1f77bcf86cd799439011"
-        update_data = {"title": "Updated Title", "description": "Updated Description"}
+        update_data: TaskRequestBody = {"title": "Updated Title", "description": "Updated Description"}
 
         response = self.make_unauthenticated_request("PATCH", account.id, task_id=fake_task_id, data=update_data)
 
@@ -249,7 +247,7 @@ class TestTaskApi(BaseTestTask):
         account1, token1 = self.create_account_and_get_token("user1@example.com", "password1")
         account2, token2 = self.create_account_and_get_token("user2@example.com", "password2")
 
-        task_data = {"title": "Account 1 Task", "description": "This belongs to account 1"}
+        task_data: TaskRequestBody = {"title": "Account 1 Task", "description": "This belongs to account 1"}
         create_response = self.make_authenticated_request("POST", account1.id, token1, data=task_data)
         assert create_response.json is not None
         account1_task_id = create_response.json.get("id")


### PR DESCRIPTION
## Context

The backend is type-checked with mypy, but the configuration in `src/apps/backend/mypy.ini` did two things that blunted it.

First, instead of `strict`, it ran a hand-picked subset of flags and set `ignore_missing_imports = True` globally. A single global mute silences typing errors for every untyped dependency at once, so a genuinely wrong call into an untyped library (a bad keyword, a wrong argument shape) never surfaces. The config even carried a TODO acknowledging this was a stopgap.

Second, it excluded the test suite entirely (`exclude = tests`). Tests were never type-checked, so a test could pass a `str` where an `int` was expected, call a service with the wrong argument shape, or drift out of sync with the code it covers, and mypy stayed silent. Tests are the code most likely to misrepresent an interface, so leaving them unchecked removes a large part of the value of typing the backend.

## What this changes

- mypy now runs in `strict` mode across both the application and the test suite.
- The global import mute is gone. Untyped dependencies are handled with narrow per-library overrides, so a wrong call into a typed library is still caught.
- Every strict finding is fixed at the source rather than suppressed.

From now on CI enforces strict typing across app and test code.

## How it works

`mypy.ini` becomes `strict = True` plus `show_error_codes = True`. The global `ignore_missing_imports` and the TODO are removed. In its place are per-library overrides for the dependencies that genuinely ship no type stubs, matched to the `Pipfile`: `bson`, `pymongo`, `celery`, `gunicorn`, `sendgrid`, `twilio`.

Two relaxations stay scoped to the exact modules that need them rather than the whole project:

- `modules.logger.internal.datadog_handler` keeps `disallow_untyped_calls = False`, because the datadog client is untyped and the handler calls into it directly.
- `celery_app` and `modules.application.worker` keep `disallow_untyped_decorators = False`, because Celery's task and signal decorators are untyped and would otherwise mark the decorated functions untyped.

The `Makefile` `run-lint` target now type-checks the tests too, with `MYPYPATH` set so intra-test imports resolve:

```
MYPYPATH=. pipenv run mypy --config-file mypy.ini . ../../../tests
```

The fixes fall into a few groups:

- **Generic containers at boundaries.** BSON `from_bson` signatures and config value types were bare `dict` / `list`; they now carry parameters (`dict[str, Any]`, `list[Any]`) consistent with the existing `to_bson` boundary.
- **Optional handling in tests.** Implicit-optional defaults (`name: str = None`) became `Optional[str]`, and Flask's `response.json` (typed `Any | None`) is narrowed with an explicit `assert ... is not None` before it is indexed or read, instead of being silenced.
- **Test helper and mock annotations.** Test helpers, `setup_method` / `teardown_method`, and patched mock parameters got return and parameter types (`MagicMock`, `Callable[..., Any]`, `TestResponse`, `FlaskClient`).
- **A latent test issue surfaced.** `test_access_auth_middleware` assigned a plain dict to `request.headers` (a Werkzeug `Headers` object); it now passes headers through `test_request_context(headers=...)`, which is both correct and what the other cases already did.

## Testing

- `make run-lint`: `mypy` reports `Success: no issues found in 154 source files` (strict, app + tests) and `pylint` is `10.00/10`.
- Backend suite: `226 passed`.

Closes #711
