### PR TITLE
ci: add local pre-push AI review hook (advisory)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Force LF (Unix) line endings for all shell scripts
 *.sh text eol=lf
+.husky/pre-push text eol=lf

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+sh "$(dirname "$0")/scripts/ai-review.sh" || exit 0

--- a/.husky/scripts/ai-review-prompt.md
+++ b/.husky/scripts/ai-review-prompt.md
@@ -1,0 +1,66 @@
+You are running as a local pre-push code reviewer for this repository. The
+engineer is about to push commits to a remote branch. Your job is to catch the
+same issues the CI code review would catch, but locally, so the engineer fixes
+them before the push instead of after.
+
+## What to review
+
+Review only the diff that is about to be pushed. Its exact range is stated at the
+top of this prompt as a git revision range (for example `origin/main..HEAD`). Run
+`git diff <range>` to see it. Do not flag pre-existing issues in unchanged code,
+and read surrounding files only as far as you need to judge the change.
+
+Do not review third-party or generated files: dependency directories
+(`node_modules`, `.venv`), build output (`dist`, `build`), or lockfiles
+(`package-lock.json`, `Pipfile.lock`). If the change only bumps a dependency,
+reason about the manifest entry, not the lockfile diff.
+
+## The standard to enforce
+
+`AGENTS.md` (root and any nested `AGENTS.md`) is the single source of truth for
+what to enforce, applied on top of general engineering best practice. `CLAUDE.md`
+points there and adds the backend module and repository detail. Read both and
+apply them exactly. This is deliberately the same standard the CI reviewer uses,
+so that issues are caught here and never reach the PR.
+
+Be high-signal. Skip nits already handled by lint, formatting, or type checks —
+those run separately. Focus on correctness bugs and on the conventions in
+`AGENTS.md` and `CLAUDE.md`: module boundaries (no imports from another module's
+`internal/`), the service/reader/writer shape, repositories as pure storage with
+typed query objects and no MongoDB syntax on their public surface, N+1 queries,
+REST CRUD semantics, business logic kept out of views and workers, security
+(no PII in logs, auth on protected routes, parameterized queries), and on the
+frontend: kebab-case file names, no `className` or inline `style` on pages,
+tokens over raw Tailwind, `PropsWithChildren` over a `children` field, `testId`
+forwarding, and accessibility.
+
+## How to act on findings — this is the important part
+
+For every issue you find, decide whether you are 100% sure it is a real problem
+with a clearly correct fix:
+
+- **If you are 100% sure**: apply the fix directly by editing the files. Make the
+  smallest change that resolves the finding and keeps the existing style. Do not
+  reformat unrelated lines.
+
+- **If you are not 100% sure** — the fix is ambiguous, there are multiple valid
+  approaches, it touches behaviour you cannot verify, or it might be intentional —
+  do NOT guess and do NOT edit. Stop and ask the engineer. Explain the concern,
+  show the relevant code, lay out the options, and let them decide. Apply their
+  decision.
+
+Never apply a fix you are not certain about. A wrong "fix" pushed silently is
+worse than a flagged question.
+
+## Loop until clean
+
+After you apply fixes (yours or the engineer's chosen ones), re-review the diff
+from scratch and repeat. Keep going until a full pass surfaces no new findings.
+Only then are you done.
+
+## When you finish
+
+End with a short summary: what you fixed, what you asked about and how it was
+resolved, and confirm the diff is clean. Leave all edits in the working tree
+(staged or unstaged) for the engineer to review and commit — do not commit,
+amend, or push anything yourself. The engineer drives the push from here.

--- a/.husky/scripts/ai-review.sh
+++ b/.husky/scripts/ai-review.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+
+set -u
+
+if [ "${AI_REVIEW:-1}" = "0" ]; then
+  exit 0
+fi
+
+if ! ( exec </dev/tty ) 2>/dev/null; then
+  exit 0
+fi
+
+detect_cmd() {
+  if [ -n "${AI_REVIEW_CMD:-}" ]; then
+    override_bin="${AI_REVIEW_CMD%% *}"
+    if ! command -v "$override_bin" >/dev/null 2>&1; then
+      echo "local-ai-review: '$override_bin' (from AI_REVIEW_CMD='${AI_REVIEW_CMD}') not found on PATH — install it or add it to PATH; if the path contains spaces, wrap it in a space-free script and point AI_REVIEW_CMD at that; or unset AI_REVIEW_CMD to auto-detect" >&2
+      return 1
+    fi
+    printf '%s\n' "$AI_REVIEW_CMD"
+    return 0
+  fi
+  for c in claude codex cursor-agent; do
+    if command -v "$c" >/dev/null 2>&1; then
+      printf '%s\n' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+AI_CMD=$(detect_cmd) || {
+  exit 0
+}
+
+AI_BIN=$(basename "${AI_CMD%% *}")
+
+ZERO="0000000000000000000000000000000000000000"
+RANGE=""
+EXTRA_REFS_PUSHED=0
+FOUND_REVIEWABLE_REF=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+  [ "$local_sha" = "$ZERO" ] && continue
+  FOUND_REVIEWABLE_REF=1
+  if [ "$remote_sha" = "$ZERO" ] || [ -z "${remote_sha:-}" ]; then
+    base=$(git merge-base origin/main "$local_sha" 2>/dev/null) || base=""
+    [ -n "$base" ] && RANGE="$base..$local_sha"
+  else
+    RANGE="$remote_sha..$local_sha"
+  fi
+  while read -r _extra_local_ref extra_sha _extra_remote_ref _extra_remote_sha; do
+    if [ -n "${extra_sha:-}" ] && [ "$extra_sha" != "$ZERO" ]; then
+      EXTRA_REFS_PUSHED=1
+      break
+    fi
+  done
+  break
+done
+
+if [ -z "$RANGE" ] && [ "$FOUND_REVIEWABLE_REF" = "1" ]; then
+  if git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+    RANGE='@{upstream}..HEAD'
+  elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+    RANGE='origin/main..HEAD'
+  else
+    echo "local-ai-review: could not determine the pushed range — reviewing only the last commit (HEAD~1..HEAD). For full coverage, review manually with 'git diff <base>..HEAD' against your branch point." >&2
+    RANGE='HEAD~1..HEAD'
+  fi
+fi
+
+[ -z "$RANGE" ] && exit 0
+if [ -z "$(git diff --name-only "$RANGE" 2>/dev/null)" ]; then
+  exit 0
+fi
+
+if [ "$EXTRA_REFS_PUSHED" = "1" ]; then
+  echo "local-ai-review: only the first pushed ref ($RANGE) was reviewed — additional refs were skipped. Push refs one at a time to review each, or review the others manually." >&2
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PROMPT_FILE="$SCRIPT_DIR/ai-review-prompt.md"
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "local-ai-review: prompt file missing at $PROMPT_FILE — restore it with 'git checkout -- .husky/scripts/ai-review-prompt.md', then push again" >&2
+  exit 0
+fi
+
+PROMPT="The diff range to review is: $RANGE
+
+$(cat "$PROMPT_FILE")"
+
+printf '\n'
+printf '%s\n' "▶ Local AI review ($AI_BIN) on $RANGE — fixing what's certain, asking when unsure."
+printf '%s\n' "  Set AI_REVIEW=0 to skip, or git push --no-verify to bypass."
+printf '\n'
+
+trap 'exit 0' INT TERM
+$AI_CMD "$PROMPT" </dev/tty >/dev/tty 2>&1
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,4 +303,5 @@ Choose your type carefully — it determines the label and semver impact.
 - [Configuration Guide](docs/configuration.md)
 - [MongoDB Security](docs/mongodb-security.md)
 - [Testing Guide](docs/testing.md)
+- [Local AI Pre-Push Review](docs/local-ai-review.md)
 - [Engineering Handbook](https://github.com/jalantechnologies/handbook/blob/main/engineering/index.md)

--- a/docs/local-ai-review.md
+++ b/docs/local-ai-review.md
@@ -1,0 +1,63 @@
+# Local AI Pre-Push Review
+
+CI runs an AI code review on every pull request: it reads the diff, applies the
+standards in `AGENTS.md`, and posts inline comments. That review is useful but it
+runs after the push, and every run spends tokens against the project's shared
+`ANTHROPIC_API_KEY` budget.
+
+The local pre-push review moves that same review onto the engineer's machine,
+before the push leaves the laptop. It uses whichever AI coding CLI the engineer
+already runs (and that engineer's own subscription), so the work is done once,
+locally, and the PR arrives already reviewed. Less back-and-forth on the PR, and
+the project's API budget is no longer spent re-reviewing the same commits on each
+push.
+
+## How it works
+
+A `pre-push` git hook (`.husky/pre-push`) runs `.husky/scripts/ai-review.sh`,
+which:
+
+1. Works out the exact range being pushed (the commits the remote does not yet
+   have) from the refs git passes to the hook.
+2. Detects the engineer's AI CLI on `PATH` — `claude`, then `codex`, then
+   `cursor-agent`.
+3. Launches that CLI interactively, seeded with `.husky/scripts/ai-review-prompt.md`,
+   which points the agent at `AGENTS.md` and `CLAUDE.md` as the standard — the
+   same source of truth CI uses.
+
+The agent reviews the diff and, for each finding:
+
+- **fixes it in place when it is 100% sure** the fix is correct, and
+- **stops and asks the engineer when it is not** — ambiguous fixes, multiple valid
+  approaches, anything it cannot verify. It never guesses.
+
+It then re-reviews and repeats until a pass surfaces nothing new. All edits are
+left in the working tree for the engineer to review and commit. The agent does
+not commit, amend, or push.
+
+## It is enabled by default, and never blocks you
+
+The hook runs automatically once you have an AI CLI installed. It is advisory:
+it never fails the push on its own, so a cancelled or crashed agent can never
+wedge a push. It skips silently (and lets the push proceed) when:
+
+- no supported AI CLI is on your `PATH`,
+- there is no terminal to drive an interactive session (CI, scripts, GUI clients),
+- you set `AI_REVIEW=0`.
+
+## Knobs
+
+| Variable        | Effect                                                                                                                                  |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `AI_REVIEW=0`   | Skip the review for this push.                                                                                                          |
+| `AI_REVIEW_CMD` | Force a specific CLI command. Per-push: `AI_REVIEW_CMD=codex git push`. Persistent: `export AI_REVIEW_CMD=codex` in your shell profile. |
+
+To bypass all git hooks for a single push, use `git push --no-verify`.
+
+## Using a CLI that isn't auto-detected
+
+If your AI CLI is not one of the detected three, set `AI_REVIEW_CMD` to its launch
+command. The contract is simple: the command is invoked with the review prompt as
+its final argument and must start an interactive session so it can ask you
+questions. Add your tool to `.husky/scripts/ai-review.sh` if the team adopts it
+widely.


### PR DESCRIPTION
## Context

This repo already runs an AI code review in CI on every pull request. It reads the PR diff, applies the standards in `AGENTS.md`, and posts inline findings, and it is a blocking gate. That review is useful, but it runs after the push, and every run spends tokens against the project's shared `ANTHROPIC_API_KEY` budget. A PR with an obvious issue burns a CI review round-trip before the engineer even sees the feedback.

This is the remaining piece of the AI-review work: the CI job landed earlier and the local hook was deliberately left for a follow-up. It closes #679.

## What this changes

Adds an optional local pre-push review that runs the same review on the engineer's own machine, before the push leaves the laptop, on whichever AI CLI the engineer already has installed. It is purely additive and advisory: it never blocks a push. The point is to catch obvious issues locally so the PR arrives already reviewed and the CI gate usually goes green on the first try, with the token spend on the engineer's own subscription rather than the project budget.

It skips silently and lets the push proceed whenever it cannot run a useful review: no supported AI CLI on `PATH`, no terminal to drive an interactive session (CI, scripts, GUI git clients), or the engineer opting out with `AI_REVIEW=0`.

## How it works

A git `pre-push` hook (wired through husky, the same mechanism the existing `pre-commit` hook uses) runs `.husky/scripts/ai-review.sh`. That script:

1. Reads the refs git feeds the hook on stdin and computes the exact range being pushed (the commits the remote does not yet have), handling new branches, branch deletions, and multiple refs.
2. Detects the engineer's AI CLI on `PATH` in order `claude` then `codex` then `cursor-agent`, overridable with `AI_REVIEW_CMD`.
3. Launches that CLI interactively against `/dev/tty`, seeded with `.husky/scripts/ai-review-prompt.md`, which points the agent at `AGENTS.md` and `CLAUDE.md` as the standard, mirroring the CI reviewer.

The agent fixes what it is certain about and asks the engineer when it is not. It never commits or pushes; all edits are left in the working tree for the engineer.

The hook is non-blocking by construction: `.husky/pre-push` swallows any non-zero status (`|| exit 0`), the script traps `INT`/`TERM` and always exits 0, and the TTY probe runs in a subshell (`( exec </dev/tty )`) so a missing `/dev/tty` is non-fatal under `dash`. A cancelled or crashed agent can never wedge a push.

`docs/local-ai-review.md` documents how it works and the `AI_REVIEW` / `AI_REVIEW_CMD` knobs, and is linked from `AGENTS.md` under Additional Resources. The env var names are the generic `AI_REVIEW` / `AI_REVIEW_CMD` rather than a project-specific prefix, since this is the public template.

## Verification

Ran the script headless (no TTY) with real pushed refs, with `AI_REVIEW=0`, and end-to-end through the generated husky shim: every path exits 0 without invoking an agent, so normal `git push` and CI are unaffected. Confirmed the same skip under `dash`. The two shell files are executable and carry LF line endings enforced via `.gitattributes`.

Closes #679
