### PR TITLE
ci: enforce backend and frontend coverage gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,6 +831,7 @@ jobs:
         continue-on-error: true
 
       - name: Coverage report
+        id: backend_coverage
         continue-on-error: true
         uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         with:
@@ -842,7 +843,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '60 80'
+          thresholds: '80 90'
 
       - name: Add coverage PR comment
         continue-on-error: true
@@ -850,6 +851,12 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+
+      - name: Enforce backend coverage threshold
+        if: steps.backend_coverage.outcome == 'failure'
+        run: |
+          echo "::error::Backend line coverage fell below the enforced floor (see the coverage report above). Add tests to bring it back over the threshold."
+          exit 1
 
   test-frontend:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
@@ -884,3 +891,37 @@ jobs:
           path: output/frontend-coverage/lcov.info
           retention-days: 1
         continue-on-error: true
+
+      - name: Coverage report
+        id: frontend_coverage
+        continue-on-error: true
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
+        with:
+          filename: output/frontend-coverage/cobertura-coverage.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '35 55'
+
+      - name: Title the frontend coverage comment
+        if: always() && hashFiles('code-coverage-results.md') != ''
+        run: |
+          printf '## Frontend\n\n%s' "$(cat code-coverage-results.md)" > code-coverage-results.md
+
+      - name: Add frontend coverage PR comment
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88
+        with:
+          header: frontend-coverage
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Enforce frontend coverage threshold
+        if: steps.frontend_coverage.outcome == 'failure'
+        run: |
+          echo "::error::Frontend line coverage fell below the enforced floor (see the coverage report above). Add tests to bring it back over the threshold."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -910,7 +910,7 @@ jobs:
       - name: Title the frontend coverage comment
         if: always() && hashFiles('code-coverage-results.md') != ''
         run: |
-          printf '## Frontend\n\n%s' "$(cat code-coverage-results.md)" > code-coverage-results.md
+          printf '## Frontend\n\n%s' "$(cat code-coverage-results.md)" > frontend-coverage-results.md
 
       - name: Add frontend coverage PR comment
         continue-on-error: true
@@ -918,7 +918,7 @@ jobs:
         with:
           header: frontend-coverage
           recreate: true
-          path: code-coverage-results.md
+          path: frontend-coverage-results.md
 
       - name: Enforce frontend coverage threshold
         if: steps.frontend_coverage.outcome == 'failure'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,21 @@ This command bootstraps the testing environment and runs `pytest` under the hood
 
 ---
 
+## Coverage Gates
+
+CI enforces a minimum coverage floor on both halves of the stack. The `test-backend` and `test-frontend` jobs each run `CodeCoverageSummary` with `fail_below_min: true`, and a follow-up step fails the build when the report step reports a shortfall. Coverage is no longer just a number in a PR comment; a drop below the floor turns the check red and blocks the merge.
+
+Current floors:
+
+| Suite    | Floor |
+| -------- | ----- |
+| Backend  | 80%   |
+| Frontend | 35%   |
+
+Each floor sits a little below where the suite actually runs today. That gap is deliberate: it lets ordinary churn move the real number up and down without going red, while still catching a genuine regression the moment coverage falls past the floor. Moving a floor is a deliberate change to the gate, not something to work around by adding assertion-free tests to pad the number.
+
+---
+
 ## Conventions & Guidelines
 
 | Topic              | Convention                                                                                          |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,12 +40,12 @@ CI enforces a minimum coverage floor on both halves of the stack. The `test-back
 
 Current floors:
 
-| Suite    | Floor |
-| -------- | ----- |
-| Backend  | 80%   |
-| Frontend | 35%   |
+| Suite    | Floor | Note                                                                          |
+| -------- | ----- | ----------------------------------------------------------------------------- |
+| Backend  | 80%   | Sits a little under the real ~86%.                                            |
+| Frontend | 35%   | Sits a little under the real ~38%; will be raised as frontend coverage grows. |
 
-Each floor sits a little below where the suite actually runs today. That gap is deliberate: it lets ordinary churn move the real number up and down without going red, while still catching a genuine regression the moment coverage falls past the floor. Moving a floor is a deliberate change to the gate, not something to work around by adding assertion-free tests to pad the number.
+Each floor sits a little below where the suite actually runs today. That gap is deliberate: it lets ordinary churn move the real number up and down without going red, while still catching a genuine regression the moment coverage falls past the floor. The frontend suite currently covers only the seed components, so its floor starts low and moves up as more of the app is tested. Moving a floor is a deliberate change to the gate, not something to work around by adding assertion-free tests to pad the number.
 
 ---
 


### PR DESCRIPTION
## Context

CI already measures coverage on both halves of the stack. The `test-backend` job runs the suite under coverage and feeds `CodeCoverageSummary`; the `test-frontend` job runs Vitest with coverage and uploads the report. But the numbers were never a gate. The backend summary step carried `continue-on-error: true`, so even with `fail_below_min` it could not turn the check red, and its thresholds (`60 80`) sat well below where the suite actually runs. The frontend job had no coverage summary at all. Coverage that is reported but never enforced drifts down one untested change at a time and nobody notices until it is too low to be worth fixing.

## What this changes

Both jobs now fail the build when line coverage falls below a floor.

- Backend floor: **80%** (the suite runs at ~86%).
- Frontend floor: **35%** (the seed suite runs at ~38%).

Each floor sits a little under the real number on purpose. That gap absorbs ordinary churn without going red, while still catching a genuine regression the moment coverage drops past the floor. The two floors are documented in `docs/testing.md`.

## How it works

`CodeCoverageSummary` reads the cobertura report and, with `fail_below_min: true`, sets its own step outcome to `failure` when line coverage is under the lower threshold. That step keeps `continue-on-error: true` so it still renders its PR comment, and a dedicated enforcement step runs only when the summary step's `outcome == 'failure'` and `exit 1`s. This is the pattern for both jobs:

- **Backend** (`test-backend`): the existing summary step gets an `id`, its threshold moves to `80 90`, and an "Enforce backend coverage threshold" step gates the job on its outcome.
- **Frontend** (`test-frontend`): a new summary step runs against `output/frontend-coverage/cobertura-coverage.xml` with `thresholds: '35 55'`, posts its own sticky comment under a distinct `frontend-coverage` header (prefixed with a `## Frontend` title so the two coverage comments do not overwrite each other), and an "Enforce frontend coverage threshold" step gates the job.

The frontend test setup itself is untouched; this change only adds the gate around the coverage it already produces.

Closes #713
