### PR TITLE
fix(auth): remove login account-enumeration via timing and error codes

### DIFF
--- a/src/apps/backend/modules/account/errors.py
+++ b/src/apps/backend/modules/account/errors.py
@@ -37,9 +37,6 @@ class AccountWithPhoneNumberNotFoundError(AccountNotFoundError):
 
 class AccountInvalidCredentialsError(AppError):
     def __init__(self) -> None:
-        # One generic answer for every failed username/password login: unknown username and wrong
-        # password are indistinguishable here on purpose. Telling them apart would confirm whether a
-        # username is registered and let an attacker enumerate accounts.
         super().__init__(
             code=AccountErrorCode.INVALID_CREDENTIALS,
             http_status_code=401,

--- a/src/apps/backend/modules/account/errors.py
+++ b/src/apps/backend/modules/account/errors.py
@@ -35,12 +35,15 @@ class AccountWithPhoneNumberNotFoundError(AccountNotFoundError):
         )
 
 
-class AccountInvalidPasswordError(AppError):
+class AccountInvalidCredentialsError(AppError):
     def __init__(self) -> None:
+        # One generic answer for every failed username/password login: unknown username and wrong
+        # password are indistinguishable here on purpose. Telling them apart would confirm whether a
+        # username is registered and let an attacker enumerate accounts.
         super().__init__(
             code=AccountErrorCode.INVALID_CREDENTIALS,
             http_status_code=401,
-            message="Incorrect password. Please try again or Reset your password if you’ve forgotten it.",
+            message="Invalid credentials. Please try again or reset your password if you’ve forgotten it.",
         )
 
 

--- a/src/apps/backend/modules/account/internal/account_reader.py
+++ b/src/apps/backend/modules/account/internal/account_reader.py
@@ -1,14 +1,14 @@
 from typing import Optional
 
 from modules.account.errors import (
-    AccountInvalidPasswordError,
+    AccountInvalidCredentialsError,
     AccountWithIdNotFoundError,
     AccountWithPhoneNumberExistsError,
     AccountWithPhoneNumberNotFoundError,
     AccountWithUserNameExistsError,
     AccountWithUsernameNotFoundError,
 )
-from modules.account.internal.account_util import AccountUtil
+from modules.account.internal.password_hash import PasswordHash
 from modules.account.internal.store.account_repository import AccountRepository
 from modules.account.types import (
     Account,
@@ -32,10 +32,18 @@ class AccountReader:
 
     @staticmethod
     def get_account_by_username_and_password(*, params: AccountSearchParams, actor: AuditActor) -> Account:
-        account = AccountReader.get_account_by_username(username=params.username, actor=actor)
+        account = AccountRepository.query_one(AccountQuery(username=params.username), actor=actor)
 
-        if not AccountUtil.compare_password(password=params.password, hashed_password=account.hashed_password):
-            raise AccountInvalidPasswordError()
+        # Every login verifies a password, even when no account matched the username. A missing account
+        # verifies against PasswordHash.absent(), which never matches but costs the same bcrypt work as a
+        # real one, so an attacker cannot learn which usernames exist from the response time. Unknown
+        # username and wrong password then raise the same error, so neither can be told from the response.
+        stored_password = PasswordHash.of(account.hashed_password) if account is not None else PasswordHash.absent()
+        password_matches = stored_password.matches(params.password)
+
+        if not password_matches or account is None:
+            raise AccountInvalidCredentialsError()
+
         return account
 
     @staticmethod

--- a/src/apps/backend/modules/account/internal/account_reader.py
+++ b/src/apps/backend/modules/account/internal/account_reader.py
@@ -34,12 +34,12 @@ class AccountReader:
     def get_account_by_username_and_password(*, params: AccountSearchParams, actor: AuditActor) -> Account:
         account = AccountRepository.query_one(AccountQuery(username=params.username), actor=actor)
 
-        # Every login verifies a password, even when no account matched the username. A missing account
-        # verifies against PasswordHash.absent(), which never matches but costs the same bcrypt work as a
-        # real one, so an attacker cannot learn which usernames exist from the response time. Unknown
-        # username and wrong password then raise the same error, so neither can be told from the response.
-        stored_password = PasswordHash.of(account.hashed_password) if account is not None else PasswordHash.absent()
-        password_matches = stored_password.matches(params.password)
+        password_to_verify = (
+            PasswordHash.of(account.hashed_password)
+            if account is not None
+            else PasswordHash.for_absent_account_with_equalized_timing()
+        )
+        password_matches = password_to_verify.matches(params.password)
 
         if not password_matches or account is None:
             raise AccountInvalidCredentialsError()

--- a/src/apps/backend/modules/account/internal/password_hash.py
+++ b/src/apps/backend/modules/account/internal/password_hash.py
@@ -1,0 +1,23 @@
+import bcrypt
+
+
+class PasswordHash:
+    # The bcrypt hash of a password nobody holds, at the same cost (rounds=10) AccountUtil.hash_password
+    # produces for a real password, so verifying against it costs the same as verifying a real one. It
+    # guards nothing and can be published; its only job is to make the absent case cost what a real one
+    # costs, so an attacker cannot learn which usernames exist from the response time.
+    _ABSENT_DIGEST = "$2b$10$lrjOG2MQ/QZO9KF0QYnx7uUOq.mct.XH0KNH03SjtgQsQ/v2lbYOO"
+
+    def __init__(self, digest: str) -> None:
+        self._digest = digest
+
+    @classmethod
+    def of(cls, digest: str) -> "PasswordHash":
+        return cls(digest)
+
+    @classmethod
+    def absent(cls) -> "PasswordHash":
+        return cls(cls._ABSENT_DIGEST)
+
+    def matches(self, password: str) -> bool:
+        return bcrypt.checkpw(password.encode("utf-8"), self._digest.encode("utf-8"))

--- a/src/apps/backend/modules/account/internal/password_hash.py
+++ b/src/apps/backend/modules/account/internal/password_hash.py
@@ -2,11 +2,7 @@ import bcrypt
 
 
 class PasswordHash:
-    # The bcrypt hash of a password nobody holds, at the same cost (rounds=10) AccountUtil.hash_password
-    # produces for a real password, so verifying against it costs the same as verifying a real one. It
-    # guards nothing and can be published; its only job is to make the absent case cost what a real one
-    # costs, so an attacker cannot learn which usernames exist from the response time.
-    _ABSENT_DIGEST = "$2b$10$lrjOG2MQ/QZO9KF0QYnx7uUOq.mct.XH0KNH03SjtgQsQ/v2lbYOO"
+    _TIMING_EQUALIZING_DIGEST_FOR_ABSENT_ACCOUNT = "$2b$10$lrjOG2MQ/QZO9KF0QYnx7uUOq.mct.XH0KNH03SjtgQsQ/v2lbYOO"
 
     def __init__(self, digest: str) -> None:
         self._digest = digest
@@ -16,8 +12,8 @@ class PasswordHash:
         return cls(digest)
 
     @classmethod
-    def absent(cls) -> "PasswordHash":
-        return cls(cls._ABSENT_DIGEST)
+    def for_absent_account_with_equalized_timing(cls) -> "PasswordHash":
+        return cls(cls._TIMING_EQUALIZING_DIGEST_FOR_ABSENT_ACCOUNT)
 
     def matches(self, password: str) -> bool:
         return bcrypt.checkpw(password.encode("utf-8"), self._digest.encode("utf-8"))

--- a/src/apps/backend/modules/authentication/rest_api/access_token_view.py
+++ b/src/apps/backend/modules/authentication/rest_api/access_token_view.py
@@ -34,7 +34,7 @@ class AccessTokenView(MethodView):
                 params=access_token_params, account=account, actor=ANONYMOUS_ACTOR
             )
         elif "username" in request_data and "password" in request_data:
-            access_token_params = EmailBasedAuthAccessTokenRequestParams(**request_data)
+            access_token_params = EmailBasedAuthAccessTokenRequestParams.from_dict(request_data)
             account = AccountService.get_account_by_username_and_password(
                 params=AccountSearchParams(
                     username=access_token_params.username, password=access_token_params.password

--- a/src/apps/backend/modules/authentication/types.py
+++ b/src/apps/backend/modules/authentication/types.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
-from modules.account.types import PhoneNumber
+from modules.account.types import AccountErrorCode, PhoneNumber
 from modules.application.common.types import QueryParams
+from modules.application.errors import AppError
 
 
 @dataclass(frozen=True)
@@ -23,6 +24,15 @@ class AccessTokenPayload:
 class EmailBasedAuthAccessTokenRequestParams:
     password: str
     username: str
+
+    @classmethod
+    def from_dict(cls, request_data: dict[str, Any]) -> "EmailBasedAuthAccessTokenRequestParams":
+        for field in ["password", "username"]:
+            if not isinstance(request_data.get(field), str):
+                raise AppError(
+                    code=AccountErrorCode.BAD_REQUEST, http_status_code=400, message=f"{field} must be a string"
+                )
+        return cls(password=request_data["password"], username=request_data["username"])
 
 
 @dataclass(frozen=True)

--- a/tests/modules/account/test_account_api/test_account_delete_api.py
+++ b/tests/modules/account/test_account_api/test_account_delete_api.py
@@ -75,8 +75,6 @@ class TestAccountDeleteApi(BaseTestAccount):
             )
             assert delete_response.status_code == 204
 
-        # A deleted account authenticates as the same generic failure as a wrong password, so its prior
-        # existence cannot be inferred from the login response.
         with self.assertRaises(AccountInvalidCredentialsError):
             AccountService.get_account_by_username_and_password(
                 params=AccountSearchParams(password="password", username=self.account.username), actor=TEST_ACTOR

--- a/tests/modules/account/test_account_api/test_account_delete_api.py
+++ b/tests/modules/account/test_account_api/test_account_delete_api.py
@@ -1,7 +1,7 @@
 from server import app
 
 from modules.account.account_service import AccountService
-from modules.account.errors import AccountWithUsernameNotFoundError
+from modules.account.errors import AccountInvalidCredentialsError
 from modules.account.types import AccountErrorCode, AccountSearchParams, CreateAccountByUsernameAndPasswordParams
 from modules.authentication.authentication_service import AuthenticationService
 from modules.authentication.types import AccessTokenErrorCode
@@ -68,14 +68,16 @@ class TestAccountDeleteApi(BaseTestAccount):
             assert get_response.json
             assert get_response.json.get("code") == AccountErrorCode.NOT_FOUND
 
-    def test_given_deleted_account_when_authenticating_then_raises_account_not_found(self) -> None:
+    def test_given_deleted_account_when_authenticating_then_raises_invalid_credentials(self) -> None:
         with app.test_client() as client:
             delete_response = client.delete(
                 f"{ACCOUNT_URL}/{self.account.id}", headers={"Authorization": f"Bearer {self.access_token.token}"}
             )
             assert delete_response.status_code == 204
 
-        with self.assertRaises(AccountWithUsernameNotFoundError):
+        # A deleted account authenticates as the same generic failure as a wrong password, so its prior
+        # existence cannot be inferred from the login response.
+        with self.assertRaises(AccountInvalidCredentialsError):
             AccountService.get_account_by_username_and_password(
                 params=AccountSearchParams(password="password", username=self.account.username), actor=TEST_ACTOR
             )

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -265,8 +265,6 @@ class TestAccountService(BaseTestAccount):
                 ACCESS_TOKEN_URL, headers=HEADERS, data=json.dumps({"username": "username", "password": "password"})
             )
 
-        # A deleted account logs in as the same generic failure as a wrong password, so a caller cannot
-        # tell a deleted account from a never-existent one or from a wrong password.
         assert login_response.status_code == 401
         assert login_response.json is not None
         assert login_response.json.get("code") == AccountErrorCode.INVALID_CREDENTIALS

--- a/tests/modules/account/test_account_service.py
+++ b/tests/modules/account/test_account_service.py
@@ -254,7 +254,7 @@ class TestAccountService(BaseTestAccount):
 
         assert response.status_code == 401
 
-    def test_deleted_account_not_found_by_username(self) -> None:
+    def test_deleted_account_login_returns_invalid_credentials(self) -> None:
         account_id, token = self._create_account_and_get_token("username", "password")
 
         with app.test_client() as client:
@@ -265,9 +265,11 @@ class TestAccountService(BaseTestAccount):
                 ACCESS_TOKEN_URL, headers=HEADERS, data=json.dumps({"username": "username", "password": "password"})
             )
 
-        assert login_response.status_code == 404
+        # A deleted account logs in as the same generic failure as a wrong password, so a caller cannot
+        # tell a deleted account from a never-existent one or from a wrong password.
+        assert login_response.status_code == 401
         assert login_response.json is not None
-        assert login_response.json.get("code") == AccountErrorCode.NOT_FOUND
+        assert login_response.json.get("code") == AccountErrorCode.INVALID_CREDENTIALS
 
     def test_deleted_account_not_found_by_id(self) -> None:
         account_id, token = self._create_account_and_get_token("username", "password")

--- a/tests/modules/authentication/test_access_token_api.py
+++ b/tests/modules/authentication/test_access_token_api.py
@@ -82,9 +82,6 @@ class TestAccessTokenApi(BaseTestAccessToken):
             assert response.json.get("code") == AccountErrorCode.INVALID_CREDENTIALS
 
     def test_unknown_username_and_wrong_password_return_byte_identical_responses(self) -> None:
-        # A distinct status, code, or message for "no such account" versus "wrong password" would confirm
-        # whether a username is registered. Both must be indistinguishable so an attacker cannot enumerate
-        # accounts from the login response.
         account = AccountService.create_account_by_username_and_password(
             params=CreateAccountByUsernameAndPasswordParams(
                 first_name="first_name", last_name="last_name", password="password", username="username"
@@ -105,9 +102,6 @@ class TestAccessTokenApi(BaseTestAccessToken):
         assert unknown_username.data == wrong_password.data
 
     def test_unknown_username_still_verifies_a_password_hash(self) -> None:
-        # The not-found path must run a full bcrypt verify against the absent-account placeholder, so a
-        # missing username costs the same time as a wrong password. Asserted via the code path rather than
-        # wall-clock: a login for an unknown username still calls PasswordHash.matches exactly once.
         with mock.patch.object(PasswordHash, "matches", return_value=False) as mock_matches:
             with app.test_client() as client:
                 response = client.post(

--- a/tests/modules/authentication/test_access_token_api.py
+++ b/tests/modules/authentication/test_access_token_api.py
@@ -1,10 +1,12 @@
 import json
 from datetime import UTC, datetime, timedelta
+from unittest import mock
 
 from server import app
 
 from modules.account.account_service import AccountService
 from modules.account.internal.account_writer import AccountWriter
+from modules.account.internal.password_hash import PasswordHash
 from modules.account.types import (
     AccountErrorCode,
     CreateAccountByPhoneNumberParams,
@@ -64,9 +66,9 @@ class TestAccessTokenApi(BaseTestAccessToken):
             response = client.post(
                 API_URL, headers=HEADERS, data=json.dumps({"username": "invalid_username", "password": "password"})
             )
-            assert response.status_code == 404
+            assert response.status_code == 401
             assert response.json
-            assert response.json.get("code") == AccountErrorCode.NOT_FOUND
+            assert response.json.get("code") == AccountErrorCode.INVALID_CREDENTIALS
 
     def test_get_access_token_with_invalid_username_and_password(self) -> None:
         with app.test_client() as client:
@@ -75,9 +77,45 @@ class TestAccessTokenApi(BaseTestAccessToken):
                 headers=HEADERS,
                 data=json.dumps({"username": "invalid_username", "password": "invalid_password"}),
             )
-            assert response.status_code == 404
+            assert response.status_code == 401
             assert response.json
-            assert response.json.get("code") == AccountErrorCode.NOT_FOUND
+            assert response.json.get("code") == AccountErrorCode.INVALID_CREDENTIALS
+
+    def test_unknown_username_and_wrong_password_return_byte_identical_responses(self) -> None:
+        # A distinct status, code, or message for "no such account" versus "wrong password" would confirm
+        # whether a username is registered. Both must be indistinguishable so an attacker cannot enumerate
+        # accounts from the login response.
+        account = AccountService.create_account_by_username_and_password(
+            params=CreateAccountByUsernameAndPasswordParams(
+                first_name="first_name", last_name="last_name", password="password", username="username"
+            ),
+            actor=TEST_ACTOR,
+        )
+
+        with app.test_client() as client:
+            unknown_username = client.post(
+                API_URL, headers=HEADERS, data=json.dumps({"username": "nobody", "password": "password"})
+            )
+            wrong_password = client.post(
+                API_URL, headers=HEADERS, data=json.dumps({"username": account.username, "password": "wrong_password"})
+            )
+
+        assert unknown_username.status_code == 401
+        assert wrong_password.status_code == 401
+        assert unknown_username.data == wrong_password.data
+
+    def test_unknown_username_still_verifies_a_password_hash(self) -> None:
+        # The not-found path must run a full bcrypt verify against the absent-account placeholder, so a
+        # missing username costs the same time as a wrong password. Asserted via the code path rather than
+        # wall-clock: a login for an unknown username still calls PasswordHash.matches exactly once.
+        with mock.patch.object(PasswordHash, "matches", return_value=False) as mock_matches:
+            with app.test_client() as client:
+                response = client.post(
+                    API_URL, headers=HEADERS, data=json.dumps({"username": "nobody", "password": "password"})
+                )
+
+        assert response.status_code == 401
+        mock_matches.assert_called_once()
 
     def test_given_phone_number_when_creating_one_time_password_then_created_at_and_updated_at_reflect_creation_time(
         self,


### PR DESCRIPTION
## Context

The username/password login endpoint (`POST /api/access-tokens`) told a client whether a given username was registered. An unknown username returned `404 ACCOUNT_ERR_02` ("we could not find an account…"), while a real username with a wrong password returned `401 ACCOUNT_ERR_03` ("incorrect password…"). On top of the different status and code, the two paths took different amounts of time: a missing account returned before any password work, while a real account paid for a full bcrypt verify first. Either signal lets an attacker take a list of candidate usernames, POST each one, and read off which are real. That is the first step of a credential-stuffing or phishing campaign, and it is a standard SOC2/pen-test finding.

This ports the hardening shipped in jalantechnologies/operate PR #493 to the template, so every project built on the template inherits a login that does not confirm or deny an account's existence.

## What this changes

Unknown username and wrong password now return a byte-identical failure: `401` with code `ACCOUNT_ERR_03` (`INVALID_CREDENTIALS`) and one generic message. The not-found path also runs a full bcrypt verify against a fixed placeholder hash, so a missing account costs about the same time as a wrong password. Nothing in the response or its latency distinguishes the two.

Scope is the username/password login path, matching the reference PR. The phone/OTP path and forgot-password (`POST /api/password-reset-tokens`) are unchanged: the issue's solution is specifically about the password-hash login path, and both of those raise on a missing account today. They are noted as separate follow-ups rather than widened into this change.

## How it works

- A new `PasswordHash` value type (`modules/account/internal/password_hash.py`) wraps a bcrypt digest. `PasswordHash.of(digest)` wraps a real account's hash; `PasswordHash.absent()` wraps a published placeholder digest at the same cost (rounds=10) the account writer uses. `matches(password)` runs `bcrypt.checkpw`. The absent digest never matches and guards nothing; its only job is to make the missing-account path cost a full verify.
- `AccountReader.get_account_by_username_and_password` now queries the account optionally, picks `PasswordHash.of(...)` or `PasswordHash.absent()`, always runs `matches`, and raises a single `AccountInvalidCredentialsError` when the password does not match or no account was found. The invariant lives in the type and the combined check, not in a comment telling the next reader not to early-return.
- The login view parses the body through a typed `EmailBasedAuthAccessTokenRequestParams.from_dict(...)` factory (typed-boundaries convention) instead of reading raw dict fields.

Rate limiting and a dedicated `LOGIN_FAILED` audit event from the reference PR are not ported: this template has no rate-limiter and its audit trail is the CRUD-based model from #739 (the credential lookup already emits a READ audit). The issue flags both as dependent on infrastructure not yet present; they are left as follow-ups.

## Tests

- Login for an unknown username and login with a wrong password assert byte-identical response bodies and the same `401` status.
- The not-found path is asserted to still call `PasswordHash.matches` exactly once (verified via the code path, not wall-clock).
- Existing tests that asserted the old enumerating behaviour (unknown username → `404 NOT_FOUND`, deleted account → `404`) are updated to the new uniform `401 INVALID_CREDENTIALS`, which is the intended change.

**SOC2 relevant.** This changes an authentication control: the login response is deliberately less specific than the internal reason, so an attacker cannot tell an unknown account from a wrong password. Closes #724.
