### PR TITLE
docs(agents): require self-explanatory code over comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,15 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 
 #### 1. Code Documentation
 
-- **DO** write comments that capture intent, invariants, or non-obvious design decisions.
-- **DON'T** narrate what the code already states.
+- **DON'T** write comments. Code must be self-explanatory: express intent through clear names, small
+  single-purpose functions, and well-named intermediate variables and helpers instead of prose.
+- A comment is a signal that the code is not clear enough. When tempted to explain a block, extract it
+  into a named helper or introduce a named constant instead.
+- The only permitted exceptions are mechanical directives the toolchain requires (`type: ignore`,
+  `pylint: disable`, `noqa`) and a single irreducible line where the *why* cannot be encoded in the
+  code itself (a non-obvious external constraint or workaround). Never narrate what the code states.
+- Docstrings follow the same rule: none, except where a public abstract base method's contract cannot
+  be conveyed by its signature.
 
 #### 2. Naming Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Use `pipenv install --dev` (from `src/apps/backend`) to bootstrap backend toolin
 - A comment is a signal that the code is not clear enough. When tempted to explain a block, extract it
   into a named helper or introduce a named constant instead.
 - The only permitted exceptions are mechanical directives the toolchain requires (`type: ignore`,
-  `pylint: disable`, `noqa`) and a single irreducible line where the *why* cannot be encoded in the
+  `pylint: disable`, `noqa`) and a single irreducible line where the _why_ cannot be encoded in the
   code itself (a non-obvious external constraint or workaround). Never narrate what the code states.
 - Docstrings follow the same rule: none, except where a public abstract base method's contract cannot
   be conveyed by its signature.


### PR DESCRIPTION
## Problem

The Code Documentation rule in AGENTS.md said to write comments for intent and why. AGENTS.md is what every background agent and the CI codereview action read on each PR, so agents kept adding explanatory comments and the review loop passed them as compliant.

## Change

Rewrite the rule to no-comments: code must be self-explanatory through naming, small single-purpose functions, and named helpers/constants. A comment is a signal that the code is not clear enough. The only exceptions are toolchain directives (`type: ignore`, `pylint`, `noqa`) and a single irreducible why-line for a constraint that cannot be encoded in code.

Docs-only. In-flight PRs will be brought in line with this rule.