### PR TITLE
ci: fix code review cost comment accumulation and no-usage pricing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          run_in=$(jq -r '[.[] | select(.type == "result")] | last | .usage.input_tokens // 0' "$EXECUTION_FILE")
-          run_out=$(jq -r '[.[] | select(.type == "result")] | last | .usage.output_tokens // 0' "$EXECUTION_FILE")
-          run_cache_read=$(jq -r '[.[] | select(.type == "result")] | last | .usage.cache_read_input_tokens // 0' "$EXECUTION_FILE")
-          run_cache_write=$(jq -r '[.[] | select(.type == "result")] | last | .usage.cache_creation_input_tokens // 0' "$EXECUTION_FILE")
+          usage=$(jq -c '
+            ([.[] | select(.type == "result") | .usage // empty] | last) as $r
+            | if $r != null then
+                {in: ($r.input_tokens // 0), out: ($r.output_tokens // 0),
+                 cread: ($r.cache_read_input_tokens // 0), cwrite: ($r.cache_creation_input_tokens // 0)}
+              else
+                ([.[] | select(.type == "assistant") | select(.message.usage != null)
+                  | {id: .message.id, u: .message.usage}] | unique_by(.id) | map(.u)) as $au
+                | {in: ([$au[].input_tokens // 0] | add // 0), out: ([$au[].output_tokens // 0] | add // 0),
+                   cread: ([$au[].cache_read_input_tokens // 0] | add // 0), cwrite: ([$au[].cache_creation_input_tokens // 0] | add // 0)}
+              end' "$EXECUTION_FILE")
+          run_in=$(printf '%s' "$usage" | jq -r '.in')
+          run_out=$(printf '%s' "$usage" | jq -r '.out')
+          run_cache_read=$(printf '%s' "$usage" | jq -r '.cread')
+          run_cache_write=$(printf '%s' "$usage" | jq -r '.cwrite')
+
+          if [ "$run_in" = "0" ] && [ "$run_out" = "0" ] && [ "$run_cache_read" = "0" ] && [ "$run_cache_write" = "0" ]; then
+            echo "::warning title=Review cost incomplete::The review ran but its transcript reported no token usage, so this run is counted as \$0 and the PR total may under-report actual spend."
+          fi
 
           catalog=$(curl -sf --max-time 15 "$CODE_REVIEW_BASE_URL/v1/model/info") || catalog=""
           if [ -z "$catalog" ]; then
@@ -216,11 +231,8 @@ jobs:
             --argjson pin "$in_price" --argjson pout "$out_price" --argjson pcache "$cache_price" \
             '(($in * $pin) + ($out * $pout) + (($cread + $cwrite) * $pcache)) / 1000000')
 
-          if [ -f .codereview-cost ]; then
-            prev='.codereview-cost'
-          else
-            echo '{"entries":[]}' > .codereview-cost.empty
-            prev='.codereview-cost.empty'
+          if [ ! -f .codereview-cost ]; then
+            echo '{"entries":[]}' > .codereview-cost
           fi
 
           jq \
@@ -235,8 +247,8 @@ jobs:
               sha: $sha, cost: $cost, input_tokens: $in, output_tokens: $out,
               cache_read_input_tokens: $cread, cache_creation_input_tokens: $cwrite
             }])}' \
-            "$prev" > .codereview-cost
-          rm -f .codereview-cost.empty
+            .codereview-cost > .codereview-cost.new
+          mv .codereview-cost.new .codereview-cost
 
           marker="<!-- codereview-cost -->"
           body=$(jq -r --arg marker "$marker" '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
             note="gateway price unavailable"
           fi
 
-          if [ ! -f .codereview-cost ]; then
+          if [ ! -s .codereview-cost ] || ! jq -e . .codereview-cost >/dev/null 2>&1; then
             echo '{"entries":[]}' > .codereview-cost
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,12 +231,20 @@ jobs:
             --argjson pin "$in_price" --argjson pout "$out_price" --argjson pcache "$cache_price" \
             '(($in * $pin) + ($out * $pout) + (($cread + $cwrite) * $pcache)) / 1000000')
 
+          note=""
+          if [ "$run_in" = "0" ] && [ "$run_out" = "0" ] && [ "$run_cache_read" = "0" ] && [ "$run_cache_write" = "0" ]; then
+            note="token usage was not reported by the review transcript"
+          elif [ "$in_price" = "0" ] && [ "$out_price" = "0" ] && [ "$cache_price" = "0" ]; then
+            note="gateway price unavailable"
+          fi
+
           if [ ! -f .codereview-cost ]; then
             echo '{"entries":[]}' > .codereview-cost
           fi
 
           jq \
             --arg sha "$HEAD_SHA" \
+            --arg note "$note" \
             --argjson cost "$run_cost" \
             --argjson in "$run_in" \
             --argjson out "$run_out" \
@@ -244,7 +252,7 @@ jobs:
             --argjson cwrite "$run_cache_write" \
             '{last_reviewed_sha: $sha,
               entries: ((.entries | map(select(.sha != $sha))) + [{
-              sha: $sha, cost: $cost, input_tokens: $in, output_tokens: $out,
+              sha: $sha, cost: $cost, note: $note, input_tokens: $in, output_tokens: $out,
               cache_read_input_tokens: $cread, cache_creation_input_tokens: $cwrite
             }])}' \
             .codereview-cost > .codereview-cost.new
@@ -259,12 +267,23 @@ jobs:
             | ($e | map(.output_tokens) | add // 0) as $tout
             | ($e | map(.cache_read_input_tokens) | add // 0) as $tcread
             | ($e | map(.cache_creation_input_tokens) | add // 0) as $tcwrite
+            | ($e | map(select((.note // "") != ""))) as $bad
+            | ($bad | length) as $nbad
+            | (if $nbad > 0 then
+                 ["> [!WARNING]",
+                  "> **This total is understated.** \($nbad) of \($n) review(s) could not be fully priced and show as $0, so the real cost is higher than below:"]
+                 + ($bad | map("> - `\(.sha[0:7])` — \(.note)"))
+                 + [">", "> This is usually a transient reporting gap; a later review typically shows a full figure.", ""]
+               else [] end) as $warn
             | [
                 $marker,
                 "### AI code review cost (PR total)",
                 "",
                 "Across **\($n)** review(s) on this PR. Estimated from DigitalOcean'"'"'s published per-token pricing for the configured model, not an authoritative bill.",
-                "",
+                ""
+              ]
+              + $warn
+              + [
                 "| Metric | Total |",
                 "| --- | --- |",
                 "| Cost (USD est.) | $\($tcost * 10000 | round / 10000) |",
@@ -278,7 +297,7 @@ jobs:
                 "| Commit | Cost (USD est.) | Input | Output | Cache read | Cache write |",
                 "| --- | --- | --- | --- | --- | --- |"
               ]
-              + ($e | map("| `\(.sha[0:7])` | $\((.cost // 0) * 10000 | round / 10000) | \(.input_tokens) | \(.output_tokens) | \(.cache_read_input_tokens) | \(.cache_creation_input_tokens) |"))
+              + ($e | map((if (.note // "") != "" then "⚠️ $" else "$" end) as $pfx | "| `\(.sha[0:7])` | \($pfx)\((.cost // 0) * 10000 | round / 10000) | \(.input_tokens) | \(.output_tokens) | \(.cache_read_input_tokens) | \(.cache_creation_input_tokens) |"))
               + ["", "</details>"]
               | join("\n")
           ' .codereview-cost)


### PR DESCRIPTION
## Summary

The per-PR "AI code review cost" comment stopped reflecting reality after the first review. This fixes the two bugs behind it, both in the `Account review cost` step of the `codereview` job. Found while verifying the DigitalOcean gateway switch (#764) on a multi-commit test PR.

**A — the running total was wiped on the 2nd+ review.**
The append read the cost file and redirected stdout back to the *same* file, so from the second review on the shell truncated the file before `jq` read it — destroying the accumulated total. The comment body was then empty, and the GitHub API rejects a comment update with an empty body (HTTP 422), which was swallowed as "transient". Now it writes to a temp file and `mv`s it into place (atomic, and it keeps the previous total if `jq` fails).

**B — a no-findings review was priced at $0.**
Token counts were read only from the `result` message's `usage`, which some no-findings runs omit (only `total_cost_usd` is present — an Anthropic-priced SDK estimate we don't use). Now it prefers `result.usage`, falls back to summing per-turn `assistant` usage (deduped by message id), and emits a visible warning if usage still can't be recovered — so a $0 is never silent.

## Evidence (before)

On a three-commit test PR: commit 1 posted the cost comment correctly ($0.0362), but commits 2 and 3 left it unchanged, each logging a swallowed `HTTP 422`.

## Testing

- **A:** three sequential appends accumulate 1 → 2 → 3 entries, the file never truncates, and the totals sum correctly.
- **B:** fixtures for (1) `result.usage` present, (2) `result.usage` absent with assistant usage (dedup verified), and (3) no usage anywhere (zeros + warning) all behave as intended.
- YAML valid; prettier passes.

Full live accumulation ("Across N reviews") will be confirmed on a non-workflow multi-commit test PR after merge — a PR that edits a workflow file can't run the review against its own changes.

## Pre-Merge Checklist

- [x] Tests pass — not applicable; CI-workflow-only change, no application code
- [x] Self-reviewed
- [x] AI code review — a PR that edits a workflow file auto-passes the gate; verified on a follow-up test PR after merge

## Additional Context

Closes #766. operate carries the same code and needs the same fix in a separate PR (out of scope here).
